### PR TITLE
Remove legacy agent spec YAML fallback

### DIFF
--- a/netlify/AGENTS.md
+++ b/netlify/AGENTS.md
@@ -34,7 +34,6 @@ agents/
 - `listTools` is built from the folders present in `agents/`.
 - `getToolManifest` and `runTool` read versions by filename (without `.md`).
 - `runTool` with `version: "latest"` sorts versions lexicographically descending and returns the first one.
-- The server prefers `.md` and falls back to legacy `.yaml`/`.yml` if present during transition.
 
 
 ## Quick Start (Local Dev)

--- a/netlify/functions/mcp.js
+++ b/netlify/functions/mcp.js
@@ -267,8 +267,8 @@ async function listVersions({ fs, path, AGENTS_DIR, tool_id }) {
   const dir = path.join(AGENTS_DIR, tool_id);
   const files = await fs.readdir(dir);
   return [...new Set(files
-    .filter((file) => /^\d+\.\d+\.\d+\.(md|ya?ml)$/i.test(file))
-    .map((file) => file.replace(/\.(md|ya?ml)$/i, "")))];
+    .filter((file) => /^\d+\.\d+\.\d+\.md$/i.test(file))
+    .map((file) => file.replace(/\.md$/i, "")))];
 }
 
 async function readAgentByName({ fs, path, AGENTS_DIR, name, version }) {
@@ -278,17 +278,8 @@ async function readAgentByName({ fs, path, AGENTS_DIR, name, version }) {
     if (!all.length) throw new Error(`No versions found for tool: ${name}`);
     v = all.sort().reverse()[0];
   }
-  for (const ext of [".md", ".yaml", ".yml"]) {
-    const filePath = path.join(AGENTS_DIR, name, `${v}${ext}`);
-    try {
-      return await fs.readFile(filePath, "utf-8");
-    } catch (error) {
-      if (error?.code !== "ENOENT") {
-        throw error;
-      }
-    }
-  }
-  throw new Error(`No spec file found for tool '${name}' version '${v}'.`);
+  const filePath = path.join(AGENTS_DIR, name, `${v}.md`);
+  return await fs.readFile(filePath, "utf-8");
 }
 
 function corsHeaders() {

--- a/website/src/components/AgentCard.jsx
+++ b/website/src/components/AgentCard.jsx
@@ -47,12 +47,12 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
         <div className="agent-actions" ref={menuRef}>
           <button className="agent-action-btn" onClick={() => setOpenMenu((v) => !v)} title="Actions">Actions ▾</button>
           {openMenu && (
-            <div className="yaml-dropdown-menu" style={{ right: 0, left: 'auto' }}>
-              <a className="yaml-dropdown-item" href={specPageUrl}>🔍 View Spec</a>
-              <a className="yaml-dropdown-item" href={rawUrl} download>⬇️ Download</a>
+            <div className="spec-dropdown-menu" style={{ right: 0, left: 'auto' }}>
+              <a className="spec-dropdown-item" href={specPageUrl}>🔍 View Spec</a>
+              <a className="spec-dropdown-item" href={rawUrl} download>⬇️ Download</a>
               {promptText && (
                 <a
-                  className="yaml-dropdown-item"
+                  className="spec-dropdown-item"
                   href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -63,7 +63,7 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
               )}
               {promptText && (
                 <a
-                  className="yaml-dropdown-item"
+                  className="spec-dropdown-item"
                   href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -72,7 +72,7 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
                   ✨ Open in Claude
                 </a>
               )}
-              <button className="yaml-dropdown-item" onClick={() => { handleCopyLink(); setOpenMenu(false); }}>🔗 Copy Link</button>
+              <button className="spec-dropdown-item" onClick={() => { handleCopyLink(); setOpenMenu(false); }}>🔗 Copy Link</button>
             </div>
           )}
         </div>

--- a/website/src/components/SpecCard.jsx
+++ b/website/src/components/SpecCard.jsx
@@ -53,50 +53,50 @@ const SpecCard = ({ spec, downloadUrl, hideHeader = false, disableMobileActions 
   const lines = (spec || '').trimEnd().split('\n');
 
   return (
-    <div className="yaml-spec-card ai-card">
-      <div className="yaml-spec-header">
+    <div className="spec-card ai-card">
+      <div className="spec-card-header">
         {!hideHeader && (
-          <div className="yaml-spec-headings">
-            <h3 className="yaml-spec-title">{specName || repoPath || 'Spec'}</h3>
-            {purpose && <p className="yaml-spec-purpose">{purpose}</p>}
+          <div className="spec-card-headings">
+            <h3 className="spec-card-title">{specName || repoPath || 'Spec'}</h3>
+            {purpose && <p className="spec-card-purpose">{purpose}</p>}
           </div>
         )}
-        <div className="yaml-actions">
+        <div className="spec-actions">
           {rawUrl && (
-            <a className="yaml-action-btn" href={rawUrl} download title="Download">⬇️ Download</a>
+            <a className="spec-action-btn" href={rawUrl} download title="Download">⬇️ Download</a>
           )}
           {viewUrl && (
-            <a className="yaml-action-btn" href={viewUrl} title="View Spec">🔍 View Spec</a>
+            <a className="spec-action-btn" href={viewUrl} title="View Spec">🔍 View Spec</a>
           )}
           {promptText && (
-            <a className="yaml-action-btn" href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" title="Open in ChatGPT">🤖 Open in ChatGPT</a>
+            <a className="spec-action-btn" href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" title="Open in ChatGPT">🤖 Open in ChatGPT</a>
           )}
           {promptText && (
-            <a className="yaml-action-btn" href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" title="Open in Claude">✨ Open in Claude</a>
+            <a className="spec-action-btn" href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" title="Open in Claude">✨ Open in Claude</a>
           )}
-          <button className="yaml-action-btn" onClick={handleCopy} title={copied ? 'Copied!' : 'Copy'}>📋 {copied ? 'Copied' : 'Copy'}</button>
+          <button className="spec-action-btn" onClick={handleCopy} title={copied ? 'Copied!' : 'Copy'}>📋 {copied ? 'Copied' : 'Copy'}</button>
         </div>
         {!disableMobileActions && (
-          <div className="yaml-actions-mobile" ref={menuRef}>
-            <button className="yaml-action-btn" onClick={() => setMenuOpen((value) => !value)} aria-haspopup="menu" aria-expanded={menuOpen} title="Actions">⋯</button>
+          <div className="spec-actions-mobile" ref={menuRef}>
+            <button className="spec-action-btn" onClick={() => setMenuOpen((value) => !value)} aria-haspopup="menu" aria-expanded={menuOpen} title="Actions">⋯</button>
             {menuOpen && (
-              <div className="yaml-dropdown-menu" role="menu">
-                {rawUrl && (<a className="yaml-dropdown-item" role="menuitem" href={rawUrl} download onClick={() => setMenuOpen(false)}>⬇️ Download</a>)}
-                {viewUrl && (<a className="yaml-dropdown-item" role="menuitem" href={viewUrl} onClick={() => setMenuOpen(false)}>🔍 View Spec</a>)}
-                {promptText && (<a className="yaml-dropdown-item" role="menuitem" href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setMenuOpen(false)}>🤖 Open in ChatGPT</a>)}
-                {promptText && (<a className="yaml-dropdown-item" role="menuitem" href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setMenuOpen(false)}>✨ Open in Claude</a>)}
-                <button className="yaml-dropdown-item" role="menuitem" onClick={() => { handleCopy(); setMenuOpen(false); }}>📋 Copy</button>
+              <div className="spec-dropdown-menu" role="menu">
+                {rawUrl && (<a className="spec-dropdown-item" role="menuitem" href={rawUrl} download onClick={() => setMenuOpen(false)}>⬇️ Download</a>)}
+                {viewUrl && (<a className="spec-dropdown-item" role="menuitem" href={viewUrl} onClick={() => setMenuOpen(false)}>🔍 View Spec</a>)}
+                {promptText && (<a className="spec-dropdown-item" role="menuitem" href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setMenuOpen(false)}>🤖 Open in ChatGPT</a>)}
+                {promptText && (<a className="spec-dropdown-item" role="menuitem" href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setMenuOpen(false)}>✨ Open in Claude</a>)}
+                <button className="spec-dropdown-item" role="menuitem" onClick={() => { handleCopy(); setMenuOpen(false); }}>📋 Copy</button>
               </div>
             )}
           </div>
         )}
       </div>
-      <div className="yaml-spec-controls" />
-      <pre className="yaml-spec-content">
+      <div className="spec-card-controls" />
+      <pre className="spec-card-content">
         {lines.map((line, idx) => (
-          <div key={idx} className="yaml-spec-line">
-            <span className="yaml-line-number" title="Copy line" onClick={() => handleCopyLine(line)}>{idx + 1}</span>
-            <span className="yaml-line-content">{line}</span>
+          <div key={idx} className="spec-card-line">
+            <span className="spec-line-number" title="Copy line" onClick={() => handleCopyLine(line)}>{idx + 1}</span>
+            <span className="spec-line-content">{line}</span>
           </div>
         ))}
       </pre>

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -182,38 +182,38 @@
 /* Add breathing room below the sticky filter bar */
 .agents-filter { margin-bottom: 2rem; }
 
-/* YAML specification card styles */
-.yaml-spec-card {
+/* Spec card styles */
+.spec-card {
   /* Inherit base ai-card styles for border, padding and background */
   position: relative;
   margin-top: 1rem;
 }
-.yaml-spec-header {
+.spec-card-header {
   margin-bottom: 0.5rem;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
 }
-.yaml-spec-title {
+.spec-card-title {
   margin: 0 0 0.5rem 0;
   font-size: 1.1rem;
   color: #00BFFF; /* accent */
   border-bottom: 2px solid rgba(0,191,255,0.25);
   display: inline-block;
 }
-.yaml-spec-purpose {
+.spec-card-purpose {
   margin: 0;
   color: var(--ifm-color-content-secondary, #334155);
   font-size: 0.9rem;
 }
-.yaml-spec-headings { max-width: 75%; }
-.yaml-spec-controls {
+.spec-card-headings { max-width: 75%; }
+.spec-card-controls {
   min-height: 0.5rem; /* spacer to preserve layout after moving actions */
 }
-.yaml-spec-toggle,
-.yaml-spec-download,
-.yaml-spec-chatgpt,
-.yaml-spec-claude {
+.spec-card-toggle,
+.spec-card-download,
+.spec-card-chatgpt,
+.spec-card-claude {
   font-size: 0.875rem;
   padding: 0.375rem 0.75rem;
   border-radius: 0.375rem;
@@ -224,20 +224,20 @@
   transition: background-color 0.2s;
   text-decoration: none;
 }
-.yaml-spec-toggle:hover,
-.yaml-spec-download:hover,
-.yaml-spec-chatgpt:hover,
-.yaml-spec-claude:hover {
+.spec-card-toggle:hover,
+.spec-card-download:hover,
+.spec-card-chatgpt:hover,
+.spec-card-claude:hover {
   background-color: var(--ifm-color-emphasis-100, #f3f4f6);
 }
-.yaml-spec-toggle:focus,
-.yaml-spec-download:focus,
-.yaml-spec-chatgpt:focus,
-.yaml-spec-claude:focus {
+.spec-card-toggle:focus,
+.spec-card-download:focus,
+.spec-card-chatgpt:focus,
+.spec-card-claude:focus {
   outline: none;
   box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.5);
 }
-.yaml-spec-copy {
+.spec-card-copy {
   font-size: 0.875rem;
   padding: 0.375rem 0.75rem;
   margin-left: 0.5rem;
@@ -248,16 +248,16 @@
   cursor: pointer;
   transition: background-color 0.2s;
 }
-.yaml-spec-copy:hover {
+.spec-card-copy:hover {
   background-color: var(--ifm-color-emphasis-100, #f3f4f6);
 }
-.yaml-spec-copy:focus {
+.spec-card-copy:focus {
   outline: none;
   box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.5);
 }
 
 /* Dropdown menu styles for Actions ▾ */
-.yaml-dropdown-menu {
+.spec-dropdown-menu {
   position: absolute;
   top: 2.25rem; /* below trigger */
   left: 0;
@@ -269,8 +269,8 @@
   padding: 0.25rem;
   z-index: 2000; /* above elevated cards */
 }
-[data-theme='dark'] .yaml-dropdown-menu { background-color: #0f172a; border-color: #2b2f36; }
-.yaml-dropdown-item {
+[data-theme='dark'] .spec-dropdown-menu { background-color: #0f172a; border-color: #2b2f36; }
+.spec-dropdown-item {
   display: block;
   width: 100%;
   text-align: left;
@@ -283,15 +283,15 @@
   text-decoration: none;
   font-size: 0.9rem;
 }
-.yaml-dropdown-item:hover,
-.yaml-dropdown-item:focus {
+.spec-dropdown-item:hover,
+.spec-dropdown-item:focus {
   background-color: var(--ifm-color-emphasis-100, #f3f4f6);
   outline: none;
 }
 
 /* Ghost icon buttons (actions) */
-.yaml-actions { display: none; gap: 0.5rem; }
-.yaml-action-btn {
+.spec-actions { display: none; gap: 0.5rem; }
+.spec-action-btn {
   border: 1px solid var(--ifm-color-emphasis-200, #e2e8f0);
   background: var(--ifm-background-surface-color);
   color: var(--ifm-color-content);
@@ -300,29 +300,29 @@
   cursor: pointer;
   text-decoration: none;
 }
-.yaml-action-btn:hover { background-color: var(--ifm-color-emphasis-100, #f3f4f6); }
-.yaml-action-btn:focus { outline: none; box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.5); }
+.spec-action-btn:hover { background-color: var(--ifm-color-emphasis-100, #f3f4f6); }
+.spec-action-btn:focus { outline: none; box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.5); }
 
-[data-theme='dark'] .yaml-action-btn {
+[data-theme='dark'] .spec-action-btn {
   border-color: #2b2f36;
   background: #0f172a;
   color: #e2e8f0;
 }
-[data-theme='dark'] .yaml-action-btn:hover { background-color: rgba(255,255,255,0.08); }
-[data-theme='dark'] .yaml-action-btn:focus { box-shadow: 0 0 0 3px rgba(255,255,255,0.35); }
+[data-theme='dark'] .spec-action-btn:hover { background-color: rgba(255,255,255,0.08); }
+[data-theme='dark'] .spec-action-btn:focus { box-shadow: 0 0 0 3px rgba(255,255,255,0.35); }
 
 /* Show icon bar on >= 640px; mobile shows kebab */
 @media (min-width: 640px) {
-  .yaml-actions { display: inline-flex; }
-  .yaml-actions-mobile { display: none; }
+  .spec-actions { display: inline-flex; }
+  .spec-actions-mobile { display: none; }
 }
 @media (max-width: 639.98px) {
-  .yaml-actions { display: none; }
-  .yaml-actions-mobile { position: relative; }
+  .spec-actions { display: none; }
+  .spec-actions-mobile { position: relative; }
 }
 
-/* YAML content visual polish */
-.yaml-spec-content {
+/* Spec content visual polish */
+.spec-card-content {
   font-family: var(--ifm-font-family-monospace);
   font-size: 15.5px;
   line-height: 1.75;
@@ -335,32 +335,32 @@
   overflow-x: auto;
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
-[data-theme='dark'] .yaml-spec-content {
+[data-theme='dark'] .spec-card-content {
   background-color: #1e1e1e; /* lighter dark */
 }
 
-.yaml-spec-line { display: flex; align-items: flex-start; }
-.yaml-line-number {
+.spec-card-line { display: flex; align-items: flex-start; }
+.spec-line-number {
   position: sticky; left: 0; z-index: 1;
   width: 3rem; text-align: right; margin-right: 0.5rem;
   color: var(--ifm-color-muted, #94a3b8);
   user-select: none; cursor: pointer;
   background: inherit; /* for sticky overlap */
 }
-.yaml-line-number:hover { color: #00BFFF; }
-.yaml-line-number:hover::after { content: ' ⎘'; color: #00BFFF; }
-.yaml-line-content { flex: 1; white-space: pre; }
+.spec-line-number:hover { color: #00BFFF; }
+.spec-line-number:hover::after { content: ' ⎘'; color: #00BFFF; }
+.spec-line-content { flex: 1; white-space: pre; }
 
 /* Simple token colors */
-.yaml-key { color: #ffcc66; font-weight: 600; }
-.yaml-string { color: #99e6ff; }
-.yaml-number { color: #f2777a; }
-.yaml-boolean { color: #a9dc76; }
-.yaml-comment { color: #999999; }
-.yaml-colon, .yaml-value, .yaml-plain { color: inherit; }
+.spec-key { color: #ffcc66; font-weight: 600; }
+.spec-string { color: #99e6ff; }
+.spec-number { color: #f2777a; }
+.spec-boolean { color: #a9dc76; }
+.spec-comment { color: #999999; }
+.spec-colon, .spec-value, .spec-plain { color: inherit; }
 
 /* Section divider */
-.yaml-section-divider {
+.spec-section-divider {
   height: 1px;
   background: currentColor;
   opacity: 0.1;
@@ -386,7 +386,7 @@
   .spec-breadcrumb-mobile { display: inline; }
 }
 
-/* Subtitle card above YAML */
+/* Subtitle card above the spec */
 .spec-subtitle-card {
   background: var(--ifm-background-surface-color);
   border: 1px solid var(--ifm-color-emphasis-200, #e2e8f0);
@@ -452,18 +452,18 @@
   .action-sheet-overlay { display: block; }
 }
 
-.yaml-spec-line {
+.spec-card-line {
   display: flex;
   align-items: flex-start;
 }
-.yaml-line-number {
+.spec-line-number {
   width: 2rem;
   text-align: right;
   margin-right: 0.5rem;
   color: var(--ifm-color-muted, #94a3b8);
   user-select: none;
 }
-.yaml-line-content {
+.spec-line-content {
   flex: 1;
   white-space: pre-wrap;
 }
@@ -472,7 +472,7 @@
 footer, footer p, footer a {
   color: var(--ifm-color-content);
 }
-.yaml-spec-content {
+.spec-card-content {
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.85rem;
   color: var(--ifm-color-content);
@@ -654,12 +654,12 @@ footer, footer p, footer a {
 [data-theme='dark'] .agent-action-btn,
 [data-theme='dark'] .mobile-actions-btn{ border-color:#2b2f36; background:#0f172a; color:#e2e8f0; }
 
-.yaml-dropdown-menu{
+.spec-dropdown-menu{
   border-radius:12px;
   border:1px solid color-mix(in srgb, var(--accent), #fff 75%);
   box-shadow:0 20px 40px -12px rgba(2,6,23,.25);
 }
-.yaml-dropdown-item:hover{ background: color-mix(in srgb, var(--accent), #fff 92%); }
+.spec-dropdown-item:hover{ background: color-mix(in srgb, var(--accent), #fff 92%); }
 
 /* Focus rings for accessibility */
 .agent-card a:focus-visible,
@@ -683,7 +683,7 @@ footer, footer p, footer a {
   color: var(--accent);
 }
 
-[data-theme='dark'] .yaml-dropdown-item:hover,
+[data-theme='dark'] .spec-dropdown-item:hover,
 [data-theme='dark'] .action-sheet-item:hover {
   background: color-mix(in srgb, var(--accent), #0f172a 75%);
 }

--- a/website/src/utils/agentSpec.js
+++ b/website/src/utils/agentSpec.js
@@ -13,7 +13,7 @@ function stripQuotes(value) {
 }
 
 export function stripSpecExtension(filename = '') {
-  return filename.replace(/\.(md|ya?ml)$/i, '');
+  return filename.replace(/\.md$/i, '');
 }
 
 export function splitFrontmatter(specText = '') {


### PR DESCRIPTION
## Summary
- remove the remaining `.yaml`/`.yml` fallback from the MCP agent spec lookup path
- make agent-spec filename handling explicitly Markdown-only in shared website helpers
- rename remaining YAML-branded agent-spec UI class names to generic spec names

## Why
The migration to Markdown is already complete. Keeping YAML fallback behavior around makes the intended source format ambiguous for future contributors and consumers.

## Verification
- npm run build

## Notes
- This is a stacked PR on top of #7 and should merge after that branch is merged or by rebasing/changing base later.