### PR TITLE
Add Claude skill distribution spec and validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "gen-mcp": "node scripts/gen-mcp-manifest.js",
     "sync-agents": "node scripts/sync-agents-static.js",
     "validate:agent-pack": "node scripts/validate-agent-pack-v0.4.0.js",
+    "validate:claude-skill": "node scripts/validate-claude-skill-pack.js",
     "build:site": "cd website && npm install && npm run build",
     "build": "npm run gen-mcp && npm run sync-agents && npm run build:site"
   },

--- a/scripts/fixtures/claude-skill-pack/invalid-missing-ref/SKILL.md
+++ b/scripts/fixtures/claude-skill-pack/invalid-missing-ref/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: bad-skill
+description: Use for invalid fixture checks.
+command: bad
+---
+
+# Broken Skill
+
+Use this skill for invalid fixture validation.
+
+## Read next
+
+- `references/overview.md`
+- `references/missing.md`

--- a/scripts/fixtures/claude-skill-pack/invalid-missing-ref/manifest.json
+++ b/scripts/fixtures/claude-skill-pack/invalid-missing-ref/manifest.json
@@ -1,0 +1,14 @@
+{
+  "tool_id": "bad-skill",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/bad-skill/0.4.0.md",
+  "display_name": "Bad Skill",
+  "description": "Use for invalid fixture checks.",
+  "files": [
+    "manifest.json",
+    "references/overview.md",
+    "SKILL.md"
+  ]
+}

--- a/scripts/fixtures/claude-skill-pack/invalid-missing-ref/references/overview.md
+++ b/scripts/fixtures/claude-skill-pack/invalid-missing-ref/references/overview.md
@@ -1,0 +1,3 @@
+# Broken Overview
+
+This fixture intentionally references a missing file and emits extra frontmatter.

--- a/scripts/fixtures/claude-skill-pack/valid-basic/SKILL.md
+++ b/scripts/fixtures/claude-skill-pack/valid-basic/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: demo-skill
+description: Use for Demo SDK setup and debugging tasks. Helps with configuration, API usage, and troubleshooting decisions.
+---
+
+# Demo Skill
+
+Use this skill when working on Demo SDK implementation or debugging tasks.
+
+## Read next
+
+- `references/overview.md`
+- `references/api-groups.md`

--- a/scripts/fixtures/claude-skill-pack/valid-basic/manifest.json
+++ b/scripts/fixtures/claude-skill-pack/valid-basic/manifest.json
@@ -1,0 +1,15 @@
+{
+  "tool_id": "demo-sdk",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/demo-sdk/0.4.0.md",
+  "display_name": "Demo SDK",
+  "description": "Use for Demo SDK setup and debugging tasks. Helps with configuration, API usage, and troubleshooting decisions.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "SKILL.md"
+  ]
+}

--- a/scripts/fixtures/claude-skill-pack/valid-basic/references/api-groups.md
+++ b/scripts/fixtures/claude-skill-pack/valid-basic/references/api-groups.md
@@ -1,0 +1,6 @@
+# Demo API Groups
+
+## Core API
+
+- `createDemoClient`
+- `runDemoTask`

--- a/scripts/fixtures/claude-skill-pack/valid-basic/references/overview.md
+++ b/scripts/fixtures/claude-skill-pack/valid-basic/references/overview.md
@@ -1,0 +1,3 @@
+# Demo Overview
+
+This is a minimal valid fixture for the Claude-compatible skill validator.

--- a/scripts/validate-claude-skill-pack.js
+++ b/scripts/validate-claude-skill-pack.js
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const args = process.argv.slice(2);
+
+if (!args.length) {
+  console.error(
+    "Usage: node scripts/validate-claude-skill-pack.js <bundle-dir> [more-bundle-dirs...]"
+  );
+  process.exit(1);
+}
+
+let hadErrors = false;
+
+for (const arg of args) {
+  const bundlePath = path.resolve(process.cwd(), arg);
+  const errors = validateBundle(bundlePath);
+  if (errors.length) {
+    hadErrors = true;
+    console.error(`\n${arg}`);
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+  } else {
+    console.log(`${arg}: OK`);
+  }
+}
+
+process.exit(hadErrors ? 1 : 0);
+
+function validateBundle(bundlePath) {
+  const errors = [];
+
+  if (!fs.existsSync(bundlePath)) {
+    return [`bundle not found: ${bundlePath}`];
+  }
+
+  if (!fs.statSync(bundlePath).isDirectory()) {
+    return [`bundle path must be a directory: ${bundlePath}`];
+  }
+
+  const skillPath = path.join(bundlePath, "SKILL.md");
+  const manifestPath = path.join(bundlePath, "manifest.json");
+
+  if (!fs.existsSync(skillPath)) {
+    errors.push("missing required file: SKILL.md");
+  }
+
+  if (!fs.existsSync(manifestPath)) {
+    errors.push("missing required file: manifest.json");
+  }
+
+  let frontmatter = null;
+  let manifest = null;
+
+  if (fs.existsSync(skillPath)) {
+    const skillText = fs.readFileSync(skillPath, "utf8");
+    frontmatter = parseFrontmatter(skillText, errors);
+    if (frontmatter) {
+      validateFrontmatter(frontmatter, errors);
+      validateSkillReferences(bundlePath, skillText, errors);
+    }
+  }
+
+  if (fs.existsSync(manifestPath)) {
+    manifest = parseManifest(manifestPath, errors);
+    if (manifest) {
+      validateManifest(bundlePath, manifest, frontmatter, errors);
+    }
+  }
+
+  return errors;
+}
+
+function parseFrontmatter(skillText, errors) {
+  if (!skillText.startsWith("---\n")) {
+    errors.push("SKILL.md must begin with YAML frontmatter");
+    return null;
+  }
+
+  const closing = skillText.indexOf("\n---\n", 4);
+  if (closing === -1) {
+    errors.push("SKILL.md frontmatter is missing a closing --- delimiter");
+    return null;
+  }
+
+  const block = skillText.slice(4, closing);
+  const lines = block.split(/\r?\n/);
+  const frontmatter = new Map();
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    const match = rawLine.match(/^([A-Za-z0-9_-]+):\s*(.+?)\s*$/);
+    if (!match) {
+      errors.push(`invalid frontmatter line: ${rawLine}`);
+      continue;
+    }
+
+    const key = match[1];
+    const value = stripQuotes(match[2]);
+    if (frontmatter.has(key)) {
+      errors.push(`duplicate frontmatter key: ${key}`);
+      continue;
+    }
+    frontmatter.set(key, value);
+  }
+
+  return frontmatter;
+}
+
+function validateFrontmatter(frontmatter, errors) {
+  const allowed = new Set(["name", "description"]);
+
+  for (const key of frontmatter.keys()) {
+    if (!allowed.has(key)) {
+      errors.push(`undocumented frontmatter field emitted: ${key}`);
+    }
+  }
+
+  const name = frontmatter.get("name");
+  const description = frontmatter.get("description");
+
+  if (!name) {
+    errors.push("frontmatter missing required field: name");
+  } else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name)) {
+    errors.push(`frontmatter name must match ^[a-z0-9]+(?:-[a-z0-9]+)*$: ${name}`);
+  }
+
+  if (!description) {
+    errors.push("frontmatter missing required field: description");
+  }
+}
+
+function validateSkillReferences(bundlePath, skillText, errors) {
+  const seen = new Set();
+  const refPatterns = [
+    /`((?:references|scripts|assets)\/[^`\n]+)`/g,
+    /\[[^\]]+\]\(((?:references|scripts|assets)\/[^)\n]+)\)/g
+  ];
+
+  for (const pattern of refPatterns) {
+    for (const match of skillText.matchAll(pattern)) {
+      const ref = match[1];
+      if (seen.has(ref)) {
+        continue;
+      }
+      seen.add(ref);
+
+      if (!isSafeRelativePath(ref)) {
+        errors.push(`invalid internal reference path: ${ref}`);
+        continue;
+      }
+
+      const refPath = path.join(bundlePath, ref);
+      if (!fs.existsSync(refPath) || !fs.statSync(refPath).isFile()) {
+        errors.push(`referenced file does not exist: ${ref}`);
+      }
+    }
+  }
+}
+
+function parseManifest(manifestPath, errors) {
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    errors.push(`manifest.json is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function validateManifest(bundlePath, manifest, frontmatter, errors) {
+  const required = [
+    "tool_id",
+    "version",
+    "distribution",
+    "entrypoint",
+    "generated_from",
+    "display_name",
+    "description",
+    "files"
+  ];
+
+  for (const key of required) {
+    if (!(key in manifest)) {
+      errors.push(`manifest.json missing required field: ${key}`);
+    }
+  }
+
+  if (typeof manifest.tool_id !== "string" || !manifest.tool_id.trim()) {
+    errors.push("manifest.json field tool_id must be a non-empty string");
+  }
+
+  if (typeof manifest.version !== "string" || !/^0\.4\.[0-9]+$/.test(manifest.version)) {
+    errors.push(`manifest.json field version must match ^0.4.[patch]: ${manifest.version}`);
+  }
+
+  if (manifest.distribution !== "claude") {
+    errors.push(`manifest.json field distribution must equal \"claude\": ${manifest.distribution}`);
+  }
+
+  if (manifest.entrypoint !== "SKILL.md") {
+    errors.push(`manifest.json field entrypoint must equal SKILL.md: ${manifest.entrypoint}`);
+  }
+
+  if (
+    typeof manifest.generated_from !== "string" ||
+    !/^agents\/.+\/0\.4\.[0-9]+\.md$/.test(manifest.generated_from)
+  ) {
+    errors.push(
+      `manifest.json field generated_from must match agents/<tool>/0.4.x.md: ${manifest.generated_from}`
+    );
+  }
+
+  if (typeof manifest.display_name !== "string" || !manifest.display_name.trim()) {
+    errors.push("manifest.json field display_name must be a non-empty string");
+  }
+
+  if (typeof manifest.description !== "string" || !manifest.description.trim()) {
+    errors.push("manifest.json field description must be a non-empty string");
+  }
+
+  if (!Array.isArray(manifest.files)) {
+    errors.push("manifest.json field files must be an array");
+    return;
+  }
+
+  const files = manifest.files;
+  const duplicates = findDuplicates(files);
+  for (const duplicate of duplicates) {
+    errors.push(`manifest.json files contains duplicate entry: ${duplicate}`);
+  }
+
+  const invalidPaths = files.filter(
+    (file) => typeof file !== "string" || !file || !isSafeRelativePath(file)
+  );
+  for (const invalidPath of invalidPaths) {
+    errors.push(`manifest.json files contains invalid path: ${String(invalidPath)}`);
+  }
+
+  if (!files.includes("SKILL.md")) {
+    errors.push("manifest.json files must include SKILL.md");
+  }
+
+  if (!files.includes("manifest.json")) {
+    errors.push("manifest.json files must include manifest.json");
+  }
+
+  const sortedFiles = [...files].sort((a, b) => a.localeCompare(b));
+  if (JSON.stringify(sortedFiles) !== JSON.stringify(files)) {
+    errors.push("manifest.json files must be sorted lexicographically");
+  }
+
+  const actualFiles = listBundleFiles(bundlePath);
+  const actualSet = new Set(actualFiles);
+  const manifestSet = new Set(files);
+
+  for (const file of files) {
+    if (!actualSet.has(file)) {
+      errors.push(`manifest.json files references missing file: ${file}`);
+    }
+  }
+
+  for (const file of actualFiles) {
+    if (!manifestSet.has(file)) {
+      errors.push(`manifest.json files is missing bundle file: ${file}`);
+    }
+  }
+
+  if (
+    frontmatter &&
+    typeof manifest.description === "string" &&
+    frontmatter.get("description") &&
+    manifest.description !== frontmatter.get("description")
+  ) {
+    errors.push("manifest.json description must match SKILL.md frontmatter description");
+  }
+}
+
+function listBundleFiles(bundlePath) {
+  const files = [];
+  walkFiles(bundlePath, bundlePath, files);
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function walkFiles(rootPath, currentPath, files) {
+  for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+    const fullPath = path.join(currentPath, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(rootPath, fullPath, files);
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(path.relative(rootPath, fullPath).split(path.sep).join("/"));
+    }
+  }
+}
+
+function stripQuotes(value) {
+  let next = (value || "").trim();
+  if (
+    (next.startsWith('"') && next.endsWith('"')) ||
+    (next.startsWith("'") && next.endsWith("'"))
+  ) {
+    next = next.slice(1, -1);
+  }
+  return next;
+}
+
+function isSafeRelativePath(filePath) {
+  return (
+    typeof filePath === "string" &&
+    !!filePath &&
+    !path.isAbsolute(filePath) &&
+    !filePath.split("/").includes("..")
+  );
+}
+
+function findDuplicates(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+      continue;
+    }
+    seen.add(value);
+  }
+  return [...duplicates].sort((a, b) => String(a).localeCompare(String(b)));
+}

--- a/spec/open-claude-skill-distribution-v0.1.md
+++ b/spec/open-claude-skill-distribution-v0.1.md
@@ -1,0 +1,341 @@
+# Open Claude Skill Distribution Spec v0.1
+
+## Purpose
+
+This document defines Agent Hub's generated Claude-compatible skill
+distribution.
+
+It does not replace the canonical Agent Hub pack format. It defines how a
+canonical `0.4.0` pack is compiled into a Claude-compatible folder bundle for
+installation and use in Claude-compatible environments.
+
+## Terminology
+
+- `canonical pack`: the authored Agent Hub source document stored at
+  `agents/<tool>/<version>.md`
+- `Claude-compatible skill`: the generated folder bundle distributed for
+  Claude-compatible environments
+- `distribution`: a delivery shape derived from the canonical pack
+
+Use `claude` as the internal distribution slug in directory names, manifest
+metadata, website selectors, and MCP responses.
+
+Use `Claude-compatible skill` as the human-facing label unless a later RFC
+updates this contract.
+
+## Scope
+
+This spec covers:
+
+- folder layout
+- required files
+- allowed frontmatter
+- section-mapping rules
+- reference-file rules
+- deterministic generation expectations
+- validation requirements
+
+This spec does not cover:
+
+- replacing the canonical Agent Hub pack format
+- MCP transport behavior
+- website route design
+- non-Claude distribution formats
+
+## Source Of Truth
+
+The source of truth for a Claude-compatible skill distribution is the canonical
+Agent Hub pack:
+
+```text
+agents/<tool>/<version>.md
+```
+
+Generated Claude-compatible skill bundles are committed artifacts under
+`distributions/claude/`. They are not hand-authored first and must not silently
+become the canonical source.
+
+## Distribution Model
+
+A Claude-compatible skill distribution is a generated folder bundle:
+
+```text
+distributions/claude/<tool>/<version>/
+  SKILL.md
+  references/
+    overview.md
+    api-groups.md
+    workflows.md
+    troubleshooting.md
+  manifest.json
+```
+
+The exact set of files under `references/` may vary by pack. Empty reference
+files must not be emitted.
+
+## Required Files
+
+### `SKILL.md`
+
+Required.
+
+This is the Claude-compatible entrypoint for the bundle.
+
+It must:
+
+- exist at the top level of the bundle
+- contain valid YAML frontmatter
+- contain at least `name` and `description`
+- stay lean compared with the canonical pack
+- explain what the skill is for and when to use it
+- point to any heavy supporting material via `references/`
+
+### `manifest.json`
+
+Required.
+
+This is Agent Hub internal distribution metadata. It is not part of Anthropic's
+required skill contract, but Agent Hub requires it for indexing, rendering, and
+machine retrieval.
+
+Required fields:
+
+- `tool_id`
+- `version`
+- `distribution`
+- `entrypoint`
+- `generated_from`
+- `display_name`
+- `description`
+- `files`
+
+### `references/`
+
+Optional in theory, expected in practice.
+
+Use `references/` for heavier material that should not live in `SKILL.md`.
+
+## Frontmatter Rules
+
+Allowed frontmatter fields in `SKILL.md`:
+
+- `name`
+- `description`
+
+No other fields should be emitted by default.
+
+If a future change adds more frontmatter fields, that change must explicitly
+update this spec.
+
+### `name`
+
+Required.
+
+Rules:
+
+- lowercase letters, digits, and hyphens only
+- stable across regenerations for the same tool
+- derived from the canonical tool identity without introducing spaces or slashes
+
+Recommended rule:
+
+- use the tool id if it already fits the pattern
+- otherwise normalize to a hyphenated variant and preserve the original tool id
+  in `manifest.json`
+
+Pattern:
+
+```text
+^[a-z0-9]+(?:-[a-z0-9]+)*$
+```
+
+### `description`
+
+Required.
+
+Rules:
+
+- concise
+- should help a Claude-compatible environment decide when the skill should load
+- should describe the domain and task class, not just restate the title
+- should avoid Agent Hub jargon such as "pack" or "expert knowledge pack"
+
+## Progressive Disclosure Rules
+
+`SKILL.md` should stay lean.
+
+It should contain:
+
+- what the skill is for
+- when to use it
+- short operational guidance
+- explicit pointers to reference files that actually exist
+
+It should not flatten the entire canonical pack into one file.
+
+Heavy or dense content should move into `references/`.
+
+## Section Mapping From Canonical Pack
+
+### Canonical `## Snapshot`
+
+Maps to:
+
+- `manifest.json`
+- optional short version or context note inside `SKILL.md`
+- optional compressed context inside `references/overview.md`
+
+Do not dump the full Snapshot block into `SKILL.md`.
+
+### Canonical `## Purpose`
+
+Maps to:
+
+- core skill purpose text in `SKILL.md`
+- optionally expanded context in `references/overview.md`
+
+### Canonical `## Guiding Principles`
+
+Maps to:
+
+- short operational guidance in `SKILL.md`
+- optionally expanded notes in `references/overview.md`
+
+### Canonical `## Design Notes`
+
+Maps to:
+
+- omitted by default
+- or compressed into `references/overview.md` only when needed to preserve real
+  operational boundaries
+
+Internal generation history must not become core skill instructions unless it is
+necessary for correct use.
+
+### Canonical `## API Groups`
+
+Maps to:
+
+- `references/api-groups.md`
+
+This is the main fidelity-preserving file.
+
+### Canonical `## Common Workflows`
+
+Maps to:
+
+- `references/workflows.md`
+
+### Canonical `## Troubleshooting Cheatsheet`
+
+Maps to:
+
+- `references/troubleshooting.md`
+
+### Canonical `## FAQ`
+
+Maps to:
+
+- `references/overview.md` when FAQ content adds meaningful context
+- omitted when it is redundant
+
+### Canonical `## External Resources`
+
+Maps to:
+
+- an optional links section inside `references/overview.md`
+- or omission when the links do not add practical value
+
+## Reference File Rules
+
+If `SKILL.md` tells the agent to read another file:
+
+- that file must exist
+- the path must be correct
+- the file should have a clear heading and focused scope
+
+Reference files should be:
+
+- one level below `references/`
+- directly discoverable from `SKILL.md`
+- organized by function, not arbitrary splitting
+
+Avoid:
+
+- deeply nested reference hierarchies
+- references that only point to more references
+- duplicate content across files
+
+## Manifest Rules
+
+`manifest.json` must contain:
+
+```json
+{
+  "tool_id": "react",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/react/0.4.0.md",
+  "display_name": "React",
+  "description": "Use for React component, hooks, rendering, and performance tasks. Helps with API usage, debugging, and implementation decisions.",
+  "files": [
+    "SKILL.md",
+    "references/api-groups.md",
+    "references/overview.md",
+    "manifest.json"
+  ]
+}
+```
+
+Rules:
+
+- `distribution` must use the internal slug `claude`
+- `entrypoint` must resolve to `SKILL.md`
+- `files` must list every file in the bundle exactly once
+- `files` must be deterministic and sorted lexicographically
+
+## Determinism Rules
+
+Generated output must be deterministic.
+
+For the same canonical input pack and generator version:
+
+- file layout must be stable
+- file names must be stable
+- section splitting must be stable
+- frontmatter values must be stable
+- manifest ordering must be stable
+
+## Validation Requirements
+
+A valid Claude-compatible skill distribution must satisfy all of the following:
+
+- `SKILL.md` exists
+- `manifest.json` exists
+- `SKILL.md` frontmatter includes valid `name` and `description`
+- no undocumented extra frontmatter fields are emitted
+- all referenced files exist
+- all files listed in `manifest.json` exist
+- `entrypoint` resolves to `SKILL.md`
+- `distribution` equals `claude`
+- generated source metadata matches the canonical pack path shape
+- no dangling internal file references exist
+- file ordering in `manifest.json` is deterministic
+
+## Recommended Validator Output
+
+Validation errors should report:
+
+- the bundle path
+- the failing rule
+- concise fix guidance
+
+## Non-Goals
+
+This distribution spec does not:
+
+- replace the canonical Agent Hub `0.4.0` source format
+- define how MCP should transport generated skill bundles
+- define how the website should render generated skill bundles
+- define Claude marketplace packaging or publishing behavior


### PR DESCRIPTION
## Summary

This PR implements PR 1 from issue #13.

It adds the first internal contract for Agent Hub's Claude-compatible skill distribution and a validator for that contract.

It does not generate production skill bundles yet.
It does not change website behavior.
It does not change MCP behavior.

## What changed

- added `spec/open-claude-skill-distribution-v0.1.md`
- added `scripts/validate-claude-skill-pack.js`
- added valid and invalid fixture bundles under `scripts/fixtures/claude-skill-pack/`
- added `npm run validate:claude-skill`

## Validation

- `npm run validate:claude-skill -- scripts/fixtures/claude-skill-pack/valid-basic`
- `node scripts/validate-claude-skill-pack.js scripts/fixtures/claude-skill-pack/invalid-missing-ref` (expected failure)
- `npm run validate:agent-pack -- agents/react/0.4.0.md`
- `npm run build`

## Notes

- internal distribution slug remains `claude`
- human-facing label remains `Claude-compatible skill`
- generated bundles are still deferred to PR 2

Refs #13
