### PR TITLE
Add website support for Claude-compatible skill distributions

### DIFF
--- a/scripts/sync-agents-static.js
+++ b/scripts/sync-agents-static.js
@@ -3,9 +3,12 @@ const path = require("path");
 
 const ROOT = path.join(__dirname, "..");
 const AGENTS_DIR = path.join(ROOT, "agents");
+const DISTRIBUTIONS_DIR = path.join(ROOT, "distributions");
 const STATIC_AGENTS_DIR = path.join(ROOT, "website/static/agents");
+const STATIC_DISTRIBUTIONS_DIR = path.join(ROOT, "website/static/distributions");
 const GENERATED_DIR = path.join(ROOT, "website/src/generated");
 const INDEX_FILE = path.join(GENERATED_DIR, "agent-index.json");
+const DISTRIBUTION_INDEX_FILE = path.join(GENERATED_DIR, "distribution-index.json");
 
 function countIndent(line) {
   return (line.match(/^\s*/)?.[0] || "").length;
@@ -108,15 +111,61 @@ function readBlockScalar(metaLines, key) {
 
 function parseMeta(specText) {
   const metaLines = extractMetaLines(specText);
-  if (!metaLines.length) {
-    return {};
+  if (metaLines.length) {
+    return {
+      specName: readScalar(metaLines, "spec_name") || readScalar(metaLines, "library_name"),
+      language: readScalar(metaLines, "language").toLowerCase(),
+      purpose: readBlockScalar(metaLines, "purpose"),
+    };
+  }
+
+  return parseStructuredMarkdownMeta(specText);
+}
+
+function parseStructuredMarkdownMeta(specText) {
+  const lines = specText.split("\n");
+  const title = lines[0]?.match(/^#\s+(.+)$/)?.[1]?.trim() || "";
+
+  const snapshotLines = getH2SectionLines(lines, "Snapshot");
+  const purposeLines = getH2SectionLines(lines, "Purpose");
+
+  const snapshotMap = new Map();
+  for (const line of snapshotLines) {
+    const match = line.match(/^-\s+([^:]+):\s+(.+)$/);
+    if (match) {
+      snapshotMap.set(match[1].trim(), match[2].trim());
+    }
   }
 
   return {
-    specName: readScalar(metaLines, "spec_name") || readScalar(metaLines, "library_name"),
-    language: readScalar(metaLines, "language").toLowerCase(),
-    purpose: readBlockScalar(metaLines, "purpose"),
+    specName: snapshotMap.get("Spec name") || title,
+    language: (snapshotMap.get("Primary language") || "").toLowerCase(),
+    purpose: purposeLines.join(" ").replace(/\s+/g, " ").trim(),
   };
+}
+
+function getH2SectionLines(lines, sectionTitle) {
+  const start = lines.findIndex((line) => line.trim() === `## ${sectionTitle}`);
+  if (start === -1) {
+    return [];
+  }
+
+  const sectionLines = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^##\s+/.test(lines[i])) {
+      break;
+    }
+    sectionLines.push(lines[i]);
+  }
+
+  while (sectionLines.length && !sectionLines[0].trim()) {
+    sectionLines.shift();
+  }
+  while (sectionLines.length && !sectionLines[sectionLines.length - 1].trim()) {
+    sectionLines.pop();
+  }
+
+  return sectionLines;
 }
 
 function copyRecursive(srcDir, destDir) {
@@ -163,10 +212,63 @@ function buildIndex() {
   });
 }
 
+function buildDistributionIndex() {
+  const distributions = [];
+
+  if (!fs.existsSync(DISTRIBUTIONS_DIR)) {
+    return distributions;
+  }
+
+  const claudeRoot = path.join(DISTRIBUTIONS_DIR, "claude");
+  if (!fs.existsSync(claudeRoot)) {
+    return distributions;
+  }
+
+  for (const project of fs.readdirSync(claudeRoot)) {
+    const projectDir = path.join(claudeRoot, project);
+    if (!fs.statSync(projectDir).isDirectory()) {
+      continue;
+    }
+
+    for (const version of fs.readdirSync(projectDir)) {
+      const versionDir = path.join(projectDir, version);
+      const manifestPath = path.join(versionDir, "manifest.json");
+      if (!fs.statSync(versionDir).isDirectory() || !fs.existsSync(manifestPath)) {
+        continue;
+      }
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      distributions.push({
+        project,
+        version,
+        distribution: manifest.distribution || "claude",
+        entrypoint: manifest.entrypoint || "SKILL.md",
+        displayName: manifest.display_name || project,
+        description: manifest.description || "",
+        files: Array.isArray(manifest.files) ? manifest.files : [],
+      });
+    }
+  }
+
+  return distributions.sort((a, b) => {
+    if (a.project !== b.project) {
+      return a.project.localeCompare(b.project);
+    }
+    return a.version.localeCompare(b.version);
+  });
+}
+
 fs.rmSync(STATIC_AGENTS_DIR, { recursive: true, force: true });
+fs.rmSync(STATIC_DISTRIBUTIONS_DIR, { recursive: true, force: true });
 copyRecursive(AGENTS_DIR, STATIC_AGENTS_DIR);
+if (fs.existsSync(DISTRIBUTIONS_DIR)) {
+  copyRecursive(DISTRIBUTIONS_DIR, STATIC_DISTRIBUTIONS_DIR);
+}
 fs.mkdirSync(GENERATED_DIR, { recursive: true });
 fs.writeFileSync(INDEX_FILE, JSON.stringify(buildIndex(), null, 2) + "\n");
+fs.writeFileSync(DISTRIBUTION_INDEX_FILE, JSON.stringify(buildDistributionIndex(), null, 2) + "\n");
 
 console.log(`✅ Agent specs synced to ${STATIC_AGENTS_DIR}`);
+console.log(`✅ Distributions synced to ${STATIC_DISTRIBUTIONS_DIR}`);
 console.log(`✅ Agent index written to ${INDEX_FILE}`);
+console.log(`✅ Distribution index written to ${DISTRIBUTION_INDEX_FILE}`);

--- a/website/src/components/AgentCard.jsx
+++ b/website/src/components/AgentCard.jsx
@@ -8,7 +8,7 @@ const accentFromString = (s) => {
   return `hsl(${h} 82% 52%)`;
 };
 
-export default function AgentCard({ project, latest, older = [], meta = {} }) {
+export default function AgentCard({ project, latest, older = [], meta = {}, latestSkill = null }) {
   const { specName, purpose, language } = meta;
   const title = specName || project;
   const [openMenu, setOpenMenu] = React.useState(false);
@@ -23,6 +23,10 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
   }, []);
 
   const specPageUrl = `/agents/spec?project=${encodeURIComponent(project)}&file=${encodeURIComponent(latest.file)}`;
+  const canonicalVersion = stripSpecExtension(latest.file);
+  const skillPageUrl = latestSkill
+    ? `/agents/skill?project=${encodeURIComponent(project)}&version=${encodeURIComponent(latestSkill.version)}`
+    : '';
   const rawUrl = `https://raw.githubusercontent.com/FIL-Builders/agent-hub/refs/heads/main/agents/${project}/${latest.file}`;
   const promptText = buildPrompt(rawUrl);
   const accent = React.useMemo(() => accentFromString(specName || project), [specName, project]);
@@ -37,8 +41,9 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
         <div>
           <h3 className="agent-card-title"><a className="agent-card-title-link" href={specPageUrl}>{title}</a></h3>
           {language && <span className="agent-lang-pill">{language}</span>}
+          {latestSkill && <span className="agent-distribution-pill">Claude-compatible skill</span>}
           <div className="agent-versions-row">
-            <span className="agent-version-latest">Latest: {stripSpecExtension(latest.file)}</span>
+            <span className="agent-version-latest">Latest canonical pack: {canonicalVersion}</span>
             {older.length > 0 && (
               <button className="agent-older-link" onClick={() => setVersionsOpen(true)}>Older Versions</button>
             )}
@@ -49,6 +54,9 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
           {openMenu && (
             <div className="spec-dropdown-menu" style={{ right: 0, left: 'auto' }}>
               <a className="spec-dropdown-item" href={specPageUrl}>🔍 View Spec</a>
+              {skillPageUrl && (
+                <a className="spec-dropdown-item" href={skillPageUrl}>🧠 View Claude Skill</a>
+              )}
               <a className="spec-dropdown-item" href={rawUrl} download>⬇️ Download</a>
               {promptText && (
                 <a
@@ -78,8 +86,18 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
         </div>
       </div>
       {purpose && <p className="agent-card-desc">{purpose}</p>}
+      {latestSkill?.description && (
+        <p className="agent-card-note">
+          {latestSkill.description}
+        </p>
+      )}
       <div className="agent-card-footer">
-        <a className="pill-link" href={specPageUrl}>{`agents/${project}/${latest.file}`}</a>
+        <div className="agent-card-footer__links">
+          <a className="pill-link" href={specPageUrl}>{`agents/${project}/${latest.file}`}</a>
+          {skillPageUrl && (
+            <a className="pill-link pill-link--accent" href={skillPageUrl}>{`distributions/claude/${project}/${latestSkill.version}/SKILL.md`}</a>
+          )}
+        </div>
         <div className="agent-mobile-actions">
           <button className="mobile-actions-btn" onClick={() => setSheetOpen(true)}>Actions ▼</button>
         </div>
@@ -108,6 +126,7 @@ export default function AgentCard({ project, latest, older = [], meta = {} }) {
           <div className="action-sheet" role="dialog" aria-label="Available Actions" onClick={(e) => e.stopPropagation()}>
             <div className="action-sheet-header">Available Actions</div>
             <a className="action-sheet-item" href={specPageUrl} onClick={() => setSheetOpen(false)}>🔍 View Spec</a>
+            {skillPageUrl && (<a className="action-sheet-item" href={skillPageUrl} onClick={() => setSheetOpen(false)}>🧠 View Claude Skill</a>)}
             <a className="action-sheet-item" href={rawUrl} download onClick={() => setSheetOpen(false)}>⬇️ Download</a>
             {promptText && (<a className="action-sheet-item" href={`https://chatgpt.com/?prompt=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setSheetOpen(false)}>🤖 Open in ChatGPT</a>)}
             {promptText && (<a className="action-sheet-item" href={`https://claude.ai/new?q=${encodeURIComponent(promptText)}`} target="_blank" rel="noopener noreferrer" onClick={() => setSheetOpen(false)}>✨ Open in Claude</a>)}

--- a/website/src/components/SkillBundleCard.jsx
+++ b/website/src/components/SkillBundleCard.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  buildSkillBundleUrl,
+  isJsonFile,
+  isMarkdownFile,
+  normalizeSkillFile,
+} from '@site/src/utils/skillBundle';
+
+export default function SkillBundleCard({
+  project,
+  version,
+  manifest,
+  selectedFile,
+  selectedContent,
+  onSelectFile,
+}) {
+  const files = manifest?.files || [];
+  const normalizedSelected = normalizeSkillFile(selectedFile || manifest?.entrypoint || 'SKILL.md');
+  const selectedDownloadUrl = buildSkillBundleUrl(project, version, normalizedSelected);
+
+  return (
+    <div className="skill-bundle-shell">
+      <aside className="skill-bundle-nav ai-card cg-glass-panel cg-industrial-border">
+        <div className="skill-bundle-nav__header">
+          <p className="agenthub-page-header__label">Claude-Compatible Skill</p>
+          <h3 className="skill-bundle-nav__title">{manifest?.displayName || project}</h3>
+          {manifest?.description ? (
+            <p className="skill-bundle-nav__copy">{manifest.description}</p>
+          ) : null}
+        </div>
+        <div className="skill-bundle-nav__meta">
+          <span className="pill-link">Distribution: {manifest?.distribution || 'claude'}</span>
+          <span className="pill-link">Version: {version}</span>
+        </div>
+        <div className="skill-bundle-nav__files">
+          {files.map((file) => (
+            <button
+              key={file}
+              className={`skill-bundle-nav__file ${file === normalizedSelected ? 'is-active' : ''}`}
+              onClick={() => onSelectFile(file)}
+              type="button"
+            >
+              {file}
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      <div className="skill-bundle-main">
+        <div className="spec-card ai-card">
+          <div className="spec-card-header">
+            <div className="spec-card-headings">
+              <p className="agenthub-page-header__label">Bundle File</p>
+              <h3 className="spec-card-title">{normalizedSelected}</h3>
+              {manifest?.generated_from ? (
+                <p className="spec-card-purpose">Generated from {manifest.generated_from}</p>
+              ) : null}
+            </div>
+            <div className="spec-actions">
+              <a className="spec-action-btn" href={selectedDownloadUrl} download>
+                ⬇️ Download File
+              </a>
+              <a
+                className="spec-action-btn"
+                href={`/agents/spec?project=${encodeURIComponent(project)}&file=${encodeURIComponent(`${version}.md`)}`}
+              >
+                🔍 View Canonical Pack
+              </a>
+            </div>
+          </div>
+          <div className="skill-bundle-install cg-glass-panel cg-industrial-border-accent">
+            <p className="skill-bundle-install__copy">
+              Install this skill in a Claude-compatible environment by copying the
+              bundle files into your local skills directory with <code>SKILL.md</code> at
+              the top level.
+            </p>
+          </div>
+          <div className="spec-card-content markdown">
+            {isMarkdownFile(normalizedSelected) ? (
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {selectedContent}
+              </ReactMarkdown>
+            ) : isJsonFile(normalizedSelected) ? (
+              <pre className="skill-bundle-code">{selectedContent}</pre>
+            ) : (
+              <pre className="skill-bundle-code">{selectedContent}</pre>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -969,6 +969,7 @@ html[data-theme='dark'] .glass-panel::after {
 }
 
 .agent-lang-pill,
+.agent-distribution-pill,
 .agent-version-latest,
 .pill-link {
   display: inline-flex;
@@ -983,6 +984,13 @@ html[data-theme='dark'] .glass-panel::after {
   padding: 0.4rem 0.6rem;
   text-decoration: none;
   word-break: break-word;
+}
+
+.agent-distribution-pill {
+  margin-left: 0.45rem;
+  border-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  background: hsl(var(--accent) / 0.16);
 }
 
 .agent-versions-row {
@@ -1013,6 +1021,13 @@ html[data-theme='dark'] .glass-panel::after {
   overflow: hidden;
 }
 
+.agent-card-note {
+  margin: 0;
+  color: hsl(var(--foreground));
+  line-height: 1.6;
+  font-size: 0.96rem;
+}
+
 .agent-card-footer {
   display: flex;
   justify-content: space-between;
@@ -1021,8 +1036,20 @@ html[data-theme='dark'] .glass-panel::after {
   margin-top: auto;
 }
 
+.agent-card-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
 .pill-link {
   color: hsl(var(--foreground));
+}
+
+.pill-link--accent {
+  border-color: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  background: hsl(var(--accent) / 0.14);
 }
 
 .pill-link:hover {
@@ -1233,6 +1260,97 @@ html[data-theme='dark'] .glass-panel::after {
 
 .spec-card-content.markdown > :last-child {
   margin-bottom: 0;
+}
+
+.skill-bundle-shell {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.72fr) minmax(0, 1.35fr);
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.skill-bundle-nav {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 1rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.2rem;
+}
+
+.skill-bundle-nav__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.skill-bundle-nav__title {
+  margin: 0;
+}
+
+.skill-bundle-nav__copy {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.6;
+}
+
+.skill-bundle-nav__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.skill-bundle-nav__files {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.skill-bundle-nav__file {
+  width: 100%;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--background) / 0.7);
+  color: hsl(var(--foreground));
+  text-align: left;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.skill-bundle-nav__file.is-active,
+.skill-bundle-nav__file:hover,
+.skill-bundle-nav__file:focus-visible {
+  border-color: hsl(var(--accent));
+  background: hsl(var(--accent) / 0.12);
+  color: hsl(var(--foreground));
+}
+
+.skill-bundle-main {
+  min-width: 0;
+}
+
+.skill-bundle-install {
+  margin: 0 0 1rem;
+  padding: 1rem 1.15rem;
+}
+
+.skill-bundle-install__copy {
+  margin: 0;
+  color: hsl(var(--foreground));
+  line-height: 1.65;
+}
+
+.skill-bundle-code {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  overflow: auto;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--secondary) / 0.12);
+  color: hsl(var(--foreground));
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.82rem;
+  line-height: 1.6;
 }
 
 .spec-card-line {
@@ -1767,6 +1885,14 @@ footer a {
     grid-template-columns: 1fr;
   }
 
+  .skill-bundle-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .skill-bundle-nav {
+    position: static;
+  }
+
   .theme-doc-sidebar-container {
     box-shadow: none;
     background: transparent;
@@ -1823,5 +1949,13 @@ footer a {
 
   .spec-card-content {
     font-size: 0.82rem;
+  }
+
+  .agent-distribution-pill {
+    margin-left: 0;
+  }
+
+  .agent-card-footer__links {
+    width: 100%;
   }
 }

--- a/website/src/pages/agents/index.jsx
+++ b/website/src/pages/agents/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import AgentCard from '@site/src/components/AgentCard';
 import agentSpecs from '@site/src/generated/agent-index.json';
+import distributionIndex from '@site/src/generated/distribution-index.json';
 import { parseAgentMeta, stripSpecExtension } from '@site/src/utils/agentSpec';
 
 export default function AgentsIndex() {
@@ -29,6 +30,13 @@ export default function AgentsIndex() {
   const [query, setQuery] = React.useState('');
   const [language, setLanguage] = React.useState('');
   const [metaByProject, setMetaByProject] = React.useState({});
+  const skillByProjectVersion = React.useMemo(() => {
+    const next = new Map();
+    distributionIndex.forEach((entry) => {
+      next.set(`${entry.project}:${entry.version}`, entry);
+    });
+    return next;
+  }, []);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -69,13 +77,15 @@ export default function AgentsIndex() {
   }, [metaByProject]);
 
   return (
-    <Layout title="All Agent Specs">
+    <Layout title="All Agent Packs">
       <main className="container agenthub-page-shell">
         <div className="agenthub-page-header cg-glass-panel cg-industrial-border">
           <p className="agenthub-page-header__label">Registry</p>
-          <h1 className="agenthub-page-header__title">All AgentHub Agent Specs</h1>
+          <h1 className="agenthub-page-header__title">All AgentHub Packs</h1>
           <p className="agenthub-page-header__copy">
-          Browse and open agent specifications. Use search and filters to find what you need.
+          Browse canonical Markdown packs and generated Claude-compatible skills.
+          Use search and filters to find the pack you need, then inspect whichever
+          distribution fits your workflow.
           </p>
         </div>
         <div className="agents-filter">
@@ -117,6 +127,7 @@ export default function AgentsIndex() {
                 latest={latestSpec}
                 older={sorted.slice(1)}
                 meta={meta}
+                latestSkill={skillByProjectVersion.get(`${project}:${stripSpecExtension(latestSpec.file)}`) || null}
               />
             );
           })}

--- a/website/src/pages/agents/skill.jsx
+++ b/website/src/pages/agents/skill.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import { useLocation } from '@docusaurus/router';
+import SkillBundleCard from '@site/src/components/SkillBundleCard';
+import {
+  buildSkillBundleUrl,
+  buildSkillManifestUrl,
+} from '@site/src/utils/skillBundle';
+
+function useQuery() {
+  const { search } = useLocation();
+  return React.useMemo(() => new URLSearchParams(search), [search]);
+}
+
+export default function AgentSkillPage() {
+  const query = useQuery();
+  const project = query.get('project');
+  const version = query.get('version');
+  const initialFile = query.get('file') || 'SKILL.md';
+
+  const [manifest, setManifest] = React.useState(null);
+  const [selectedFile, setSelectedFile] = React.useState(initialFile);
+  const [selectedContent, setSelectedContent] = React.useState('');
+  const [status, setStatus] = React.useState('loading');
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    setError('');
+    setManifest(null);
+    setSelectedContent('');
+    if (!project || !version) {
+      setStatus('error');
+      setError('Missing project or version parameter');
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    fetch(buildSkillManifestUrl(project, version))
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load manifest (${response.status})`);
+        }
+        return response.json();
+      })
+      .then((nextManifest) => {
+        if (!cancelled) {
+          setManifest(nextManifest);
+          setSelectedFile(initialFile || nextManifest.entrypoint || 'SKILL.md');
+        }
+      })
+      .catch((nextError) => {
+        if (!cancelled) {
+          setStatus('error');
+          setError(nextError?.message || String(nextError));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [project, version, initialFile]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!manifest || !project || !version || !selectedFile) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setStatus('loading');
+    setError('');
+    fetch(buildSkillBundleUrl(project, version, selectedFile))
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load bundle file (${response.status})`);
+        }
+        return response.text();
+      })
+      .then((content) => {
+        if (!cancelled) {
+          setSelectedContent(content);
+          setStatus('ready');
+        }
+      })
+      .catch((nextError) => {
+        if (!cancelled) {
+          setStatus('error');
+          setError(nextError?.message || String(nextError));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [manifest, project, version, selectedFile]);
+
+  return (
+    <Layout title={project && version ? `${project} – Claude Skill ${version}` : 'Claude-Compatible Skill'}>
+      <main className="container spec-page agenthub-page-shell">
+        <div className="spec-page-nav">
+          <a href="/agents/" className="spec-breadcrumb spec-breadcrumb-desktop">← All Agent Packs</a>
+          <a href="/agents/" className="spec-breadcrumb spec-breadcrumb-mobile">← Back</a>
+        </div>
+        {status === 'loading' && (
+          <div className="ai-card cg-glass-panel cg-industrial-border" aria-busy="true">
+            <div className="spec-skeleton">
+              <div className="skeleton skeleton-title" />
+              <div className="skeleton skeleton-subtitle" />
+              <div className="skeleton skeleton-subtitle short" />
+              <div className="skeleton-code">
+                {[80, 95, 60, 85, 70, 90, 50, 88].map((w, i) => (
+                  <div key={i} className="skeleton skeleton-line" style={{ width: `${w}%` }} />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {status === 'ready' && manifest ? (
+          <>
+            <div className="agenthub-page-header cg-glass-panel cg-industrial-border">
+              <p className="agenthub-page-header__label">Distribution</p>
+              <h1 className="spec-page-title">{project} / Claude-compatible skill / {version}</h1>
+              <p className="agenthub-page-header__copy">
+                Inspect the generated Claude-compatible skill bundle alongside the
+                canonical Markdown pack.
+              </p>
+            </div>
+            <SkillBundleCard
+              project={project}
+              version={version}
+              manifest={manifest}
+              selectedFile={selectedFile}
+              selectedContent={selectedContent}
+              onSelectFile={setSelectedFile}
+            />
+          </>
+        ) : null}
+
+        {status === 'error' && (
+          <div className="ai-card cg-glass-panel cg-industrial-border">
+            <h3>Claude-Compatible Skill Not Found</h3>
+            <p>
+              Unable to load the generated skill for project <code>{project || '(missing)'}</code> and
+              version <code>{version || '(missing)'}</code>.
+            </p>
+            <p style={{ color: 'var(--ifm-color-muted, #94a3b8)' }}>{error}</p>
+          </div>
+        )}
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/utils/agentSpec.js
+++ b/website/src/utils/agentSpec.js
@@ -111,16 +111,57 @@ function readBlockScalar(metaLines, key) {
 export function parseAgentMeta(specText = '') {
   try {
     const metaLines = extractMetaLines(specText);
-    if (!metaLines.length) {
-      return {};
+    if (metaLines.length) {
+      const specName = readScalar(metaLines, 'spec_name') || readScalar(metaLines, 'library_name');
+      const language = readScalar(metaLines, 'language').toLowerCase();
+      const purpose = readBlockScalar(metaLines, 'purpose');
+
+      return { specName, language, purpose };
     }
 
-    const specName = readScalar(metaLines, 'spec_name') || readScalar(metaLines, 'library_name');
-    const language = readScalar(metaLines, 'language').toLowerCase();
-    const purpose = readBlockScalar(metaLines, 'purpose');
+    const lines = specText.split('\n');
+    const title = lines[0]?.match(/^#\s+(.+)$/)?.[1]?.trim() || '';
+    const snapshotLines = getH2SectionLines(lines, 'Snapshot');
+    const purposeLines = getH2SectionLines(lines, 'Purpose');
+    const snapshotMap = new Map();
+
+    snapshotLines.forEach((line) => {
+      const match = line.match(/^-\s+([^:]+):\s+(.+)$/);
+      if (match) {
+        snapshotMap.set(match[1].trim(), match[2].trim());
+      }
+    });
+
+    const specName = snapshotMap.get('Spec name') || title;
+    const language = (snapshotMap.get('Primary language') || '').toLowerCase();
+    const purpose = purposeLines.join(' ').replace(/\s+/g, ' ').trim();
 
     return { specName, language, purpose };
   } catch {
     return {};
   }
+}
+
+function getH2SectionLines(lines, sectionTitle) {
+  const start = lines.findIndex((line) => line.trim() === `## ${sectionTitle}`);
+  if (start === -1) {
+    return [];
+  }
+
+  const collected = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^##\s+/.test(lines[i])) {
+      break;
+    }
+    collected.push(lines[i]);
+  }
+
+  while (collected.length && !collected[0].trim()) {
+    collected.shift();
+  }
+  while (collected.length && !collected[collected.length - 1].trim()) {
+    collected.pop();
+  }
+
+  return collected;
 }

--- a/website/src/utils/skillBundle.js
+++ b/website/src/utils/skillBundle.js
@@ -1,0 +1,19 @@
+export function buildSkillBundleUrl(project, version, file = 'SKILL.md') {
+  return `/distributions/claude/${project}/${version}/${file}`;
+}
+
+export function buildSkillManifestUrl(project, version) {
+  return buildSkillBundleUrl(project, version, 'manifest.json');
+}
+
+export function normalizeSkillFile(file = '') {
+  return file.replace(/^\/+/, '');
+}
+
+export function isMarkdownFile(file = '') {
+  return /\.md$/i.test(file);
+}
+
+export function isJsonFile(file = '') {
+  return /\.json$/i.test(file);
+}

--- a/website/static/distributions/claude/agent-hub/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/agent-hub/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: agent-hub
+description: Use for Agent Hub MCP retrieval, pack discovery, version selection, onboarding, and pack-authoring workflow tasks. Helps with runtime context delivery, version pinning, and contribution decisions.
+---
+
+# Agent Hub
+
+Use this skill when the task is about Agent Hub itself: fetching packs, choosing versions, onboarding an agent, or creating and revising Agent Hub packs.
+
+## Purpose
+
+This pack teaches an agent to use Agent Hub as a versioned context-delivery system: discover available packs, inspect versions, fetch the exact pack needed at task time, verify MCP-based retrieval without overfitting the workflow to any single example pack such as `react`, and follow the repo’s own v0.4 pack generation workflow when creating or revising Agent Hub packs locally.
+
+## When to use this skill
+
+- Agent Hub MCP setup and verification
+- pack discovery, version selection, and fetch decisions
+- prompt-based onboarding and persistent routing guidance
+- Agent Hub pack authoring and review workflow
+
+## Working style
+
+- Treat Agent Hub as both a registry of versioned packs and a delivery layer for those packs.
+- Prefer just-in-time retrieval over pasting large packs into every prompt up front.
+- Use explicit versions when you need reproducible, auditable behavior.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/agent-hub/0.4.0/manifest.json
+++ b/website/static/distributions/claude/agent-hub/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "agent-hub",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/agent-hub/0.4.0.md",
+  "display_name": "Agent Hub",
+  "description": "Use for Agent Hub MCP retrieval, pack discovery, version selection, onboarding, and pack-authoring workflow tasks. Helps with runtime context delivery, version pinning, and contribution decisions.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/agent-hub/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/agent-hub/0.4.0/references/api-groups.md
@@ -1,0 +1,604 @@
+# Agent Hub API Groups
+
+### MCP Tools
+**Exports**
+- agenthub_list
+- agenthub_versions
+- agenthub_fetch
+- agenthub_docs
+
+The callable MCP tool surface for browsing, version inspection, raw pack fetches,
+and self-describing server docs.
+
+#### agenthub_list
+**Kind**
+function
+
+**Summary**
+List available Agent Hub packs with simple pagination and optional substring
+filtering by `tool_id`.
+
+**Definition**
+Language: typescript
+Source: `netlify/functions/mcp.js`
+
+```ts
+agenthub_list({
+  q?: string,
+  limit?: number,
+  offset?: number
+}) => {
+  total: number;
+  limit: number;
+  offset: number;
+  nextOffset: number | null;
+  q: string;
+  items: Array<{ tool_id: string; versions: string[] }>;
+}
+```
+
+**Guidance**
+- Use this first when you know the general domain but not the exact `tool_id`.
+- Filtering is only on `tool_id`; do not expect descriptions or tags to be indexed.
+- Page through large result sets with `offset` instead of assuming the whole registry fits in one response.
+
+**Example**
+Language: json
+Description: Search for tool IDs containing `sdk`.
+
+```json
+{
+  "name": "agenthub_list",
+  "arguments": {
+    "q": "sdk",
+    "limit": 10
+  }
+}
+```
+
+#### agenthub_versions
+**Kind**
+function
+
+**Summary**
+List the versions available for one Agent Hub pack.
+
+**Definition**
+Language: typescript
+Source: `netlify/functions/mcp.js`
+
+```ts
+agenthub_versions({
+  tool_id: string
+}) => {
+  tool_id: string;
+  versions: string[];
+}
+```
+
+**Guidance**
+- Use this when you already know the `tool_id` and need to decide between `latest` and a pinned version.
+- Reach for explicit versions in production, evaluations, and debugging so the retrieved context is reproducible.
+- Do not assume version ordering is semver-aware; the server resolves `latest` lexicographically.
+
+**Example**
+Language: json
+Description: Check which versions exist for the Agent Hub pack itself.
+
+```json
+{
+  "name": "agenthub_versions",
+  "arguments": {
+    "tool_id": "agent-hub"
+  }
+}
+```
+
+#### agenthub_fetch
+**Kind**
+function
+
+**Summary**
+Fetch the raw Markdown spec for a tool at a chosen version, or resolve the
+lexicographically highest version when `latest` is requested.
+
+**Definition**
+Language: typescript
+Source: `netlify/functions/mcp.js`
+
+```ts
+agenthub_fetch({
+  tool_id: string,
+  version?: string
+}) => string;
+```
+
+**Guidance**
+- This is the main runtime retrieval path when an agent actually needs pack content.
+- Prefer fetching only the relevant pack for the current task instead of loading many packs speculatively.
+- Use `version: "latest"` for exploration and an explicit version for repeatable evaluations, tests, or agent workflows.
+- Fetching `agent-hub` itself is a strong verification step because it proves the registry can serve its own product pack cleanly.
+
+**Example**
+Language: json
+Description: Fetch the latest Agent Hub pack.
+
+```json
+{
+  "name": "agenthub_fetch",
+  "arguments": {
+    "tool_id": "agent-hub",
+    "version": "latest"
+  }
+}
+```
+
+#### agenthub_docs
+**Kind**
+function
+
+**Summary**
+Return the server’s own MCP usage docs as JSON text.
+
+**Definition**
+Language: typescript
+Source: `netlify/functions/mcp.js`
+
+```ts
+agenthub_docs({}) => {
+  name: string;
+  transport: string;
+  endpoint: string;
+  usage: Record<string, string>;
+  tools: Array<unknown>;
+  notes: string[];
+  health: Record<string, string>;
+}
+```
+
+**Guidance**
+- Use this when you need to inspect the tool surface or explain setup without separately opening the server source.
+- It is useful for self-diagnosis when the agent can connect to the MCP server but is unsure how to call the tools.
+- Do not confuse these docs with the fetched pack content; this tool explains the server, not a target library.
+
+**Example**
+Language: json
+Description: Retrieve the server docs payload.
+
+```json
+{
+  "name": "agenthub_docs",
+  "arguments": {}
+}
+```
+
+### Connection Model
+**Exports**
+- MCP endpoint
+- docs endpoint
+- direct HTTP config
+- mcp-remote config
+
+Operational connection paths for human setup and agent-assisted onboarding.
+
+#### MCP endpoint
+**Kind**
+endpoint
+
+**Summary**
+The deployed Streamable HTTP MCP endpoint that exposes Agent Hub tools.
+
+**Definition**
+Language: text
+Source: `tutorials/use-agent-hub-through-mcp.md`, `netlify/functions/mcp.js`
+
+```text
+https://agent-hub-1.netlify.app/mcp
+```
+
+**Guidance**
+- Use this URL for direct client configuration and manual JSON-RPC testing.
+- Manual calls should send `Accept: application/json, text/event-stream`.
+- Treat the endpoint as the runtime surface; human-readable docs live at the docs variants below.
+
+**Example**
+Language: text
+Description: Direct MCP endpoint value for manual or client configuration.
+
+```text
+https://agent-hub-1.netlify.app/mcp
+```
+
+#### docs endpoint
+**Kind**
+endpoint
+
+**Summary**
+Human-readable or JSON docs for the deployed MCP server.
+
+**Definition**
+Language: text
+Source: `tutorials/use-agent-hub-through-mcp.md`, `netlify/functions/mcp.js`
+
+```text
+https://agent-hub-1.netlify.app/mcp?format=text
+https://agent-hub-1.netlify.app/mcp?format=json
+```
+
+**Guidance**
+- Use the JSON docs for tooling, introspection, or debugging.
+- Use the text docs for quick human inspection.
+- Prefer `agenthub_docs` once the MCP connection is working; prefer `?format=json` when the connection is not set up yet.
+
+**Example**
+Language: text
+Description: Human-readable and JSON docs endpoints for Agent Hub MCP.
+
+```text
+https://agent-hub-1.netlify.app/mcp?format=text
+https://agent-hub-1.netlify.app/mcp?format=json
+```
+
+#### direct HTTP config
+**Kind**
+config
+
+**Summary**
+Preferred MCP client configuration when the client supports Streamable HTTP directly.
+
+**Definition**
+Language: json
+Source: `tutorials/use-agent-hub-through-mcp.md`
+
+```json
+{
+  "mcpServers": {
+    "agent-hub": {
+      "url": "https://agent-hub-1.netlify.app/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+**Guidance**
+- Prefer this over proxy-based setups when the client supports it natively.
+- Preserve existing MCP servers in the config; do not replace the whole block unnecessarily.
+- Use the smallest correct change when editing a client config automatically.
+
+**Example**
+Language: json
+Description: Minimal direct HTTP MCP config block.
+
+```json
+{
+  "mcpServers": {
+    "agent-hub": {
+      "url": "https://agent-hub-1.netlify.app/mcp",
+      "transport": "http"
+    }
+  }
+}
+```
+
+#### mcp-remote config
+**Kind**
+config
+
+**Summary**
+Fallback configuration pattern for clients that require an MCP proxy wrapper.
+
+**Definition**
+Language: json
+Source: `tutorials/use-agent-hub-through-mcp.md`
+
+```json
+{
+  "mcpServers": {
+    "agent-hub": {
+      "command": "npx",
+      "args": ["mcp-remote@next", "https://agent-hub-1.netlify.app/mcp"]
+    }
+  }
+}
+```
+
+**Guidance**
+- Use this only when the client does not support direct HTTP MCP configuration.
+- Explain to users why the proxy is required instead of treating it as the default path.
+- When onboarding inside an AI client, detect the correct config style before proposing a snippet.
+
+**Example**
+Language: json
+Description: Proxy-style config for clients that require `mcp-remote`.
+
+```json
+{
+  "mcpServers": {
+    "agent-hub": {
+      "command": "npx",
+      "args": ["mcp-remote@next", "https://agent-hub-1.netlify.app/mcp"]
+    }
+  }
+}
+```
+
+### Registry Semantics
+**Exports**
+- tool_id
+- version pinning
+- latest resolution
+- agents directory layout
+
+Rules that govern how packs are named, versioned, and resolved.
+
+#### tool_id
+**Kind**
+other
+
+**Summary**
+The stable identifier for one pack family, usually matching the folder name
+under `agents/`.
+
+**Definition**
+Language: text
+Source: `netlify/functions/mcp.js`
+
+```text
+agents/<tool_id>/<version>.md
+```
+
+**Guidance**
+- Use `tool_id` consistently across `agenthub_versions` and `agenthub_fetch`.
+- Keep new IDs simple and avoid characters likely to be sanitized by clients.
+- Distinguish the product `agent-hub` pack from example packs like `react`; the latter are verification targets, not the definition of Agent Hub itself.
+
+**Example**
+Language: text
+Description: The on-disk path shape that determines one pack family.
+
+```text
+agents/agent-hub/0.4.0.md
+```
+
+#### version pinning
+**Kind**
+workflow
+
+**Summary**
+The practice of fetching an explicit pack version instead of relying on `latest`.
+
+**Definition**
+Language: text
+Source: `tutorials/use-agent-hub-through-mcp.md`, `website/src/pages/index.js`
+
+```text
+Use explicit versions for reproducible behavior, evaluations, and auditability.
+```
+
+**Guidance**
+- Pin versions for tests, benchmark runs, and long-lived agent workflows.
+- Use `latest` when exploring or when freshness matters more than reproducibility.
+- Be explicit in user-facing summaries about which version was fetched and why.
+
+**Example**
+Language: json
+Description: Fetch a pinned Agent Hub pack version for reproducible behavior.
+
+```json
+{
+  "name": "agenthub_fetch",
+  "arguments": {
+    "tool_id": "agent-hub",
+    "version": "0.4.0"
+  }
+}
+```
+
+#### latest resolution
+**Kind**
+other
+
+**Summary**
+The server resolves `latest` by choosing the lexicographically highest version string.
+
+**Definition**
+Language: text
+Source: `netlify/functions/mcp.js`
+
+```text
+latest = [...versions].sort().reverse()[0]
+```
+
+**Guidance**
+- Do not assume semver-aware ordering.
+- If a precise version matters, call `agenthub_versions` and choose explicitly.
+- Surface this nuance when troubleshooting unexpected `latest` behavior.
+
+**Example**
+Language: text
+Description: Current server rule for resolving `latest`.
+
+```text
+latest = lexicographically highest available version string
+```
+
+#### agents directory layout
+**Kind**
+other
+
+**Summary**
+The on-disk layout that backs both the registry and the MCP server.
+
+**Definition**
+Language: text
+Source: `netlify/functions/mcp.js`, `README.md`
+
+```text
+agents/<tool_id>/<version>.md
+```
+
+**Guidance**
+- This is the source of truth for what the server can list and fetch.
+- Missing folders or versioned files mean the MCP server cannot serve that pack.
+- When creating a new pack, keep the naming consistent so direct file access and MCP access agree.
+
+**Example**
+Language: text
+Description: Agent Hub's filesystem-backed registry layout.
+
+```text
+agents/<tool_id>/<version>.md
+```
+
+### Pack Generation Surface
+**Exports**
+- open-agent-spec-v0.4.0
+- authoritative-documents-for-v0.4-pack-generation
+- evaluating-agenthub-pack-outputs
+- codex-agent-pack-runbook-v0.4.0
+- codex-generate-agent-file-v0.4.0
+
+The documents and prompts that govern how Agent Hub packs should be generated,
+reviewed, and evaluated locally.
+
+#### open-agent-spec-v0.4.0
+**Kind**
+other
+
+**Summary**
+The normative Markdown specification that defines what a valid `0.4.0` Agent Hub
+pack must contain.
+
+**Definition**
+Language: text
+Source: `spec/open-agent-spec-v0.4.0.md`
+
+```text
+spec/open-agent-spec-v0.4.0.md
+```
+
+**Guidance**
+- Start here when generating or revising packs, because it defines required sections, field names, symbol structure, and allowed `Kind` values.
+- If another repo document disagrees with the pack structure, the spec wins.
+- Treat this as the contract for pack shape, not as a content-generation tutorial.
+
+**Example**
+Language: text
+Description: Normative spec path for v0.4 pack structure.
+
+```text
+spec/open-agent-spec-v0.4.0.md
+```
+
+#### authoritative-documents-for-v0.4-pack-generation
+**Kind**
+workflow
+
+**Summary**
+The tutorial that defines which repo documents are authoritative for pack generation decisions.
+
+**Definition**
+Language: text
+Source: `tutorials/authoritative-documents-for-v0.4-pack-generation.md`
+
+```text
+tutorials/authoritative-documents-for-v0.4-pack-generation.md
+```
+
+**Guidance**
+- Use this when you need to know whether the spec, validator, runbook, prompts, or generated artifacts should win in a conflict.
+- This is the best first tutorial for contributors generating or revising packs locally.
+- It is especially important when an AI coding agent is deciding which local files to trust during generation.
+
+**Example**
+Language: text
+Description: Authority-chain tutorial path for v0.4 pack generation.
+
+```text
+tutorials/authoritative-documents-for-v0.4-pack-generation.md
+```
+
+#### evaluating-agenthub-pack-outputs
+**Kind**
+workflow
+
+**Summary**
+The guide for comparing two candidate pack outputs by inspection and task-based evaluation.
+
+**Definition**
+Language: text
+Source: `tutorials/evaluating-agenthub-pack-outputs.md`
+
+```text
+tutorials/evaluating-agenthub-pack-outputs.md
+```
+
+**Guidance**
+- Use this when deciding whether a regenerated pack is actually better than an older one.
+- Keep the comparison controlled: same task, same model family, same constraints, different pack inputs.
+- Treat this as the acceptance process for content quality, not as the structural spec.
+
+**Example**
+Language: text
+Description: Evaluation tutorial path for pack comparisons.
+
+```text
+tutorials/evaluating-agenthub-pack-outputs.md
+```
+
+#### codex-agent-pack-runbook-v0.4.0
+**Kind**
+workflow
+
+**Summary**
+The operational runbook for executing a pack-generation task under the `v0.4` process.
+
+**Definition**
+Language: text
+Source: `prompts/codex-agent-pack-runbook-v0.4.0.md`
+
+```text
+prompts/codex-agent-pack-runbook-v0.4.0.md
+```
+
+**Guidance**
+- Follow this when a local AI coding agent is doing the generation work and needs explicit execution order, source hierarchy, and completion checks.
+- The runbook governs workflow mechanics; it does not override the spec on structure.
+- Use it to keep source acquisition, critique, revision, and validation consistent across generation runs.
+
+**Example**
+Language: text
+Description: Operational runbook path for v0.4 generation tasks.
+
+```text
+prompts/codex-agent-pack-runbook-v0.4.0.md
+```
+
+#### codex-generate-agent-file-v0.4.0
+**Kind**
+workflow
+
+**Summary**
+The general worker prompt for drafting a final `v0.4` Agent Hub pack from the current source set.
+
+**Definition**
+Language: text
+Source: `prompts/codex-generate-agent-file-v0.4.0.md`
+
+```text
+prompts/codex-generate-agent-file-v0.4.0.md
+```
+
+**Guidance**
+- Use this as the generic generation worker prompt when no tool-specific brief exists yet.
+- Pair it with the runbook, the spec, and any tool-specific brief for better results.
+- Treat tool-specific generation briefs as refinements of this base prompt, not replacements for the authority chain.
+
+**Example**
+Language: text
+Description: Base worker prompt path for final agent-pack drafting.
+
+```text
+prompts/codex-generate-agent-file-v0.4.0.md
+```

--- a/website/static/distributions/claude/agent-hub/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/agent-hub/0.4.0/references/overview.md
@@ -1,0 +1,80 @@
+# Agent Hub Overview
+
+## Snapshot
+
+- Spec name: agent-hub
+- Spec version: 0.4.0
+- Generated: 2026-03-14
+- Library version: current-docs + mcp-server^1.1.0
+- Primary language: markdown
+- Homepage: https://github.com/FIL-Builders/agent-hub
+- Source set: `README.md`, `netlify/functions/mcp.js`, `netlify/functions/mcp-health.js`, `tutorials/use-agent-hub-through-mcp.md`, `blog/0005-why-agenthub-mcp-won-react-context-test.md`, `website/src/components/AIAgentOnboardingPrompt.jsx`, `website/src/pages/index.js`, and `spec/open-agent-spec-v0.4.0.md`
+
+**Tags**
+- agent-hub
+- mcp
+- ai-agents
+- markdown
+- context-delivery
+- registry
+
+## Purpose
+
+This pack teaches an agent to use Agent Hub as a versioned context-delivery
+system: discover available packs, inspect versions, fetch the exact pack needed
+at task time, verify MCP-based retrieval without overfitting the workflow to
+any single example pack such as `react`, and follow the repo’s own v0.4 pack
+generation workflow when creating or revising Agent Hub packs locally.
+
+## Guiding Principles
+
+- Treat Agent Hub as both a registry of versioned packs and a delivery layer for those packs.
+- Prefer just-in-time retrieval over pasting large packs into every prompt up front.
+- Use explicit versions when you need reproducible, auditable behavior.
+- Use `latest` for exploration, prototyping, and first-pass retrieval only.
+- Verify MCP setup by listing tools and successfully fetching one known pack.
+- Keep onboarding generic across AI clients; do not assume one specific CLI or IDE.
+- Treat benchmark posts as proof points, not as the full product definition.
+- Treat the pack-generation workflow as a first-class Agent Hub surface, not just an internal maintainer detail.
+- When generating or revising packs, follow the authority chain: spec, validator, runbook, prompts, then generated artifacts.
+
+## Boundary Notes
+
+- The authoritative runtime surface comes from `netlify/functions/mcp.js`, which defines the deployed MCP endpoint, transport shape, tool set, and the human-readable docs payload.
+- `tutorials/use-agent-hub-through-mcp.md` is the primary operational guide for setup, verification, and manual JSON-RPC examples.
+- The React comparison post is used as product evidence for why delivery quality matters; it is not the contract source for MCP behavior.
+- Homepage and onboarding prompt content are used to preserve the current product framing around versioned guidance, onboarding, and direct MCP setup.
+- Agent Hub is a current-docs product pack, so version-sensitive claims are kept grounded in the checked-in docs and current Netlify MCP implementation rather than a package manifest alone.
+- The pack-generation workflow is grounded in `spec/open-agent-spec-v0.4.0.md`, the authoritative-documents tutorial, the evaluation guide, and the checked-in generation prompts. Those sources are used to teach contribution behavior, not just runtime MCP use.
+
+## FAQ
+
+### Is Agent Hub only for React?
+No. React is a commonly used benchmark or verification example because it is easy
+to test and widely understood, but Agent Hub is a general registry and MCP server
+for many packs across APIs, frameworks, SDKs, and product surfaces.
+
+### When should I use MCP instead of opening a pack file directly?
+Use MCP when you want runtime retrieval, version inspection, or a cleaner path
+inside an MCP-aware client. Open a pack file directly when you are working
+locally, reviewing content by hand, or the environment does not support MCP.
+
+### Does this pack also teach how to create Agent Hub packs?
+Yes. This pack covers both runtime use of Agent Hub and the local contribution workflow for generating or revising packs under the `v0.4` process. Use the authority-chain and evaluation tutorials when the task is pack creation rather than runtime retrieval.
+
+### Does using Agent Hub guarantee better answers?
+No. Agent Hub improves retrieval discipline, version clarity, and repeatability.
+It can improve outcomes, as shown in the React proof post, but it does not
+replace judgment, source evaluation, or task-specific reasoning.
+
+## External Resources
+
+- Agent Hub repository: https://github.com/FIL-Builders/agent-hub
+- Agent Hub MCP tutorial: https://github.com/FIL-Builders/agent-hub/blob/main/tutorials/use-agent-hub-through-mcp.md
+- Agent Hub pack-generation authority guide: https://github.com/FIL-Builders/agent-hub/blob/main/tutorials/authoritative-documents-for-v0.4-pack-generation.md
+- Agent Hub pack evaluation guide: https://github.com/FIL-Builders/agent-hub/blob/main/tutorials/evaluating-agenthub-pack-outputs.md
+- Agent Hub React proof post: https://github.com/FIL-Builders/agent-hub/blob/main/blog/0005-why-agenthub-mcp-won-react-context-test.md
+- Open Agent Spec v0.4.0: https://github.com/FIL-Builders/agent-hub/blob/main/spec/open-agent-spec-v0.4.0.md
+- Agent Hub generation runbook: https://github.com/FIL-Builders/agent-hub/blob/main/prompts/codex-agent-pack-runbook-v0.4.0.md
+- Deployed MCP docs JSON: https://agent-hub-1.netlify.app/mcp?format=json
+- Deployed MCP docs text: https://agent-hub-1.netlify.app/mcp?format=text

--- a/website/static/distributions/claude/agent-hub/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/agent-hub/0.4.0/references/troubleshooting.md
@@ -1,0 +1,50 @@
+# Agent Hub Troubleshooting
+
+### The client can connect but no tools appear
+**Cause**
+- The client config was edited in the wrong location, the client does not support the chosen transport, or the client needs a proxy-style MCP setup instead of direct HTTP.
+
+**Fix**
+- Confirm the actual config path for the current client.
+- Check whether the client needs direct HTTP or an `mcp-remote` wrapper.
+- Use the docs URL directly to confirm the deployed endpoint is alive even if the client integration is failing.
+
+### `latest` fetched an unexpected version
+**Cause**
+- The server resolves `latest` with lexicographic sorting, so the result may differ from a semver-aware expectation.
+
+**Fix**
+- Call `agenthub_versions` first, inspect the available versions, and pin the exact version you want.
+
+### A fetch failed for a `tool_id`
+**Cause**
+- The requested `tool_id` or version does not match what exists under `agents/<tool_id>/<version>.md`, or the caller is using a display-sanitized name instead of the true registry ID.
+
+**Fix**
+- Use `agenthub_list` or `agenthub_versions` to confirm the exact `tool_id`.
+- Fetch only versions that actually exist for that tool.
+- Treat client-side tool-name sanitization as a UI concern only; the underlying `tool_id` still needs to match the server registry.
+
+### The agent is fetching too much context
+**Cause**
+- The agent is treating Agent Hub like a blob store and preloading many packs before it knows which one the task actually needs.
+
+**Fix**
+- Fetch only the pack relevant to the active task, and only when needed.
+- If reproducibility matters, inspect versions first and then fetch the single pinned pack you plan to use.
+
+### A generated pack passes structure checks but still feels weak
+**Cause**
+- Structural validation only proves the pack matches the spec and validator; it does not prove the content is the strongest version of the pack.
+
+**Fix**
+- Run the candidate through the evaluation guide and compare it against the prior pack on realistic tasks.
+- Tighten the source set, workflows, troubleshooting, and guidance before treating the new pack as canonical.
+
+### The generator is unsure which local document should win
+**Cause**
+- The repo contains normative documents, prompts, validators, tutorials, and generated artifacts with different authority levels.
+
+**Fix**
+- Use `tutorials/authoritative-documents-for-v0.4-pack-generation.md` to resolve the conflict.
+- In general, prefer the spec for structure, the validator for automated enforcement, the runbook/prompts for workflow, and generated artifacts only as run-specific outputs or examples.

--- a/website/static/distributions/claude/agent-hub/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/agent-hub/0.4.0/references/workflows.md
@@ -1,0 +1,35 @@
+# Agent Hub Workflows
+
+### AI Agent Onboarding
+1. Detect whether the current AI client supports MCP configuration and identify the correct config path or settings location.
+2. Add an `agent-hub` server using direct HTTP when supported, or an `mcp-remote` pattern when required.
+3. Preserve existing MCP servers and make the smallest safe change.
+4. Verify the connection by listing tools and fetching a known pack. Prefer the `agent-hub` pack itself for a product-level verification step.
+5. Summarize what changed, what worked, and any manual follow-up still required.
+
+### Just-In-Time Retrieval
+1. Identify the library or tool relevant to the task.
+2. If reproducibility matters, call `agenthub_versions` before fetching.
+3. Fetch only the one pack that the current task actually needs.
+4. Use the fetched Markdown as runtime context, not as a permanent blob pasted into every prompt.
+5. Report the fetched `tool_id` and version in the final answer when the workflow needs auditability.
+
+### Manual Verification
+1. Confirm the endpoint or docs URL is reachable.
+2. Verify the client can see the `agenthub_list`, `agenthub_versions`, `agenthub_fetch`, and `agenthub_docs` tools.
+3. Fetch a known pack, such as `agent-hub` or another task-relevant example.
+4. If manual JSON-RPC is needed, send `Content-Type: application/json` and `Accept: application/json, text/event-stream`.
+
+### Generate or Revise a Pack Locally
+1. Start with `spec/open-agent-spec-v0.4.0.md` to understand the pack contract.
+2. Read `tutorials/authoritative-documents-for-v0.4-pack-generation.md` to know which repo documents are authoritative for the task.
+3. Use the checked-in `v0.4` prompts and runbook to generate a draft pack locally with your AI coding agent.
+4. Run `node scripts/validate-agent-pack-v0.4.0.js <path-to-pack>` and fix all structural failures.
+5. Compare the candidate output using `tutorials/evaluating-agenthub-pack-outputs.md` before treating it as an improvement over the prior pack.
+6. Open a GitHub PR so the pack, prompts, and validation story remain reviewable in one place.
+
+### Choose the Right Tutorial
+1. Use `tutorials/use-agent-hub-through-mcp.md` when the task is connecting Agent Hub MCP and retrieving packs at runtime.
+2. Use `tutorials/authoritative-documents-for-v0.4-pack-generation.md` when the task is creating or revising a pack.
+3. Use `tutorials/evaluating-agenthub-pack-outputs.md` when the task is comparing candidate pack outputs.
+4. Do not substitute the MCP tutorial for the pack-generation authority chain; they solve different problems.

--- a/website/static/distributions/claude/nextjs/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/nextjs/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: nextjs
+description: Use for Next.js App Router, data fetching, rendering, and deployment tasks. Helps with framework APIs, routing, caching, and production debugging.
+---
+
+# Next.js
+
+Use this skill when the task depends on Next.js framework behavior, especially App Router rendering, routing, caching, or deployment conventions.
+
+## Purpose
+
+This pack teaches an agent to use Next.js 16 effectively across App Router, Pages Router compatibility, rendering boundaries, request helpers, caching and revalidation, and framework-specific routing behavior without collapsing those concerns into generic React advice.
+
+## When to use this skill
+
+- App Router routing and layout structure
+- server and client component boundaries
+- data fetching, caching, and revalidation
+- framework-specific debugging and deployment
+
+## Working style
+
+- Default to App Router mental models for new work unless the task is explicitly about Pages Router or migration.
+- Keep server components, client components, route handlers, server actions, and Pages Router data functions as distinct execution contexts.
+- Treat `next/navigation` hooks as Client Component APIs and `headers()` / `cookies()` / `redirect()` as server-side control or request APIs.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/nextjs/0.4.0/manifest.json
+++ b/website/static/distributions/claude/nextjs/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "nextjs",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/nextjs/0.4.0.md",
+  "display_name": "Next.js",
+  "description": "Use for Next.js App Router, data fetching, rendering, and deployment tasks. Helps with framework APIs, routing, caching, and production debugging.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/nextjs/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/nextjs/0.4.0/references/api-groups.md
@@ -1,0 +1,775 @@
+# Next.js API Groups
+
+### App Router Navigation And Client Routing
+**Exports**
+- Link
+- useRouter
+- usePathname
+- useSearchParams
+- Route
+
+These are the most common client-facing navigation surfaces in current Next.js.
+
+#### Link
+**Kind**
+component
+
+**Summary**
+Framework navigation component for internal links with Next.js-aware prefetch and routing behavior.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/link.d.ts
+
+```ts
+type Url = string | UrlObject;
+
+export interface LinkProps<RouteInferType = any> {
+  href: Url;
+  as?: Url;
+  replace?: boolean;
+  scroll?: boolean;
+  shallow?: boolean;
+  passHref?: boolean;
+  prefetch?: boolean | "auto" | null;
+  locale?: string | false;
+  legacyBehavior?: boolean;
+}
+
+declare const Link: React.ForwardRefExoticComponent<...>;
+```
+
+**Guidance**
+- Use `Link` for internal navigation instead of raw `<a>` when you want framework routing and prefetch behavior.
+- Prefetch semantics differ between App Router and Pages Router, so explain them in router-specific terms.
+- Do not rely on `legacyBehavior` for new code; it exists for compatibility.
+
+**Example**
+Language: tsx
+Description: Navigate to a dashboard page from a Client or Server Component render tree.
+
+```tsx
+import Link from "next/link";
+
+export default function Nav() {
+  return (
+    <nav>
+      <Link href="/dashboard">Dashboard</Link>
+    </nav>
+  );
+}
+```
+
+#### useRouter
+**Kind**
+hook
+
+**Summary**
+Client Component hook for imperative App Router navigation.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/components/navigation.d.ts
+
+```ts
+import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+export declare function useRouter(): AppRouterInstance;
+```
+
+**Guidance**
+- Use this only in Client Components.
+- Prefer declarative navigation with `Link` unless you truly need imperative behavior such as post-submit navigation.
+- Do not confuse this App Router hook with legacy `next/router` usage from the Pages Router era.
+
+**Example**
+Language: tsx
+Description: Navigate after a client-side event.
+
+```tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function GoButton() {
+  const router = useRouter();
+  return (
+    <button type="button" onClick={() => router.push("/settings")}>
+      Open settings
+    </button>
+  );
+}
+```
+
+#### usePathname
+**Kind**
+hook
+
+**Summary**
+Client Component hook that returns the current pathname.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/components/navigation.d.ts
+
+```ts
+export declare function usePathname(): string;
+```
+
+**Guidance**
+- Use this in Client Components when UI behavior depends on the current route path.
+- Do not use it as a substitute for route params when you need structured dynamic segment data.
+- Keep route matching logic narrow; avoid broad pathname string heuristics when route structure is known.
+
+**Example**
+Language: tsx
+Description: Highlight the active section based on the current pathname.
+
+```tsx
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export default function ActivePath() {
+  const pathname = usePathname();
+  return <p>Current path: {pathname}</p>;
+}
+```
+
+#### useSearchParams
+**Kind**
+hook
+
+**Summary**
+Client Component hook that exposes read-only URL search parameters.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/components/navigation.d.ts
+
+```ts
+import { ReadonlyURLSearchParams } from "next/dist/client/components/navigation.react-server";
+
+export declare function useSearchParams(): ReadonlyURLSearchParams;
+```
+
+**Guidance**
+- Use this only in Client Components.
+- Treat the return value as read-only query state derived from the URL.
+- If the task needs server-side access to search params, keep that logic in server-side entry points instead of pulling this hook into the server tree.
+
+**Example**
+Language: tsx
+Description: Read the current filter from the query string.
+
+```tsx
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export default function FilterLabel() {
+  const searchParams = useSearchParams();
+  const filter = searchParams.get("filter") ?? "all";
+  return <span>Filter: {filter}</span>;
+}
+```
+
+#### Route
+**Kind**
+type
+
+**Summary**
+Framework route type used for statically typed link and navigation targets.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/types.d.ts
+
+```ts
+export type Route<RouteInferType = any> = string & {};
+```
+
+**Guidance**
+- Use this when you want type-checked route values in helpers or wrapper components.
+- Treat it as compile-time help, not as runtime validation that a route exists.
+- Keep build-time route generation in mind; some route typing features depend on Next.js build outputs.
+
+**Example**
+Language: tsx
+Description: Restrict a custom link wrapper to framework route strings.
+
+```tsx
+import Link from "next/link";
+import type { Route } from "next";
+
+type NavItemProps = {
+  href: Route;
+  label: string;
+};
+
+export function NavItem({ href, label }: NavItemProps) {
+  return <Link href={href}>{label}</Link>;
+}
+```
+
+### Server Request And Control APIs
+**Exports**
+- headers
+- cookies
+- redirect
+- notFound
+
+These APIs are server-side request and control-flow primitives.
+
+#### headers
+**Kind**
+function
+
+**Summary**
+Reads incoming request headers in server-side Next.js execution contexts.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/server/request/headers.d.ts
+
+```ts
+import { type ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
+
+export declare function headers(): Promise<ReadonlyHeaders>;
+```
+
+**Guidance**
+- Await this in Server Components, Route Handlers, Server Actions, or Middleware-compatible server code.
+- Do not import this into Client Components.
+- Use it for request-derived behavior, not as a general-purpose config or environment store.
+
+**Example**
+Language: ts
+Description: Read a custom request header in a server entry point.
+
+```ts
+import { headers } from "next/headers";
+
+export default async function Page() {
+  const requestHeaders = await headers();
+  const requestId = requestHeaders.get("x-request-id");
+  return <pre>{requestId ?? "no request id"}</pre>;
+}
+```
+
+#### cookies
+**Kind**
+function
+
+**Summary**
+Reads request cookies in server-side Next.js execution contexts.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/server/request/cookies.d.ts
+
+```ts
+import { type ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+
+export declare function cookies(): Promise<ReadonlyRequestCookies>;
+```
+
+**Guidance**
+- Await this in server-side code paths.
+- Treat cookie reads as request-scoped behavior; do not try to use this in Client Components.
+- Keep auth, personalization, and cache behavior aligned when cookie-dependent rendering is involved.
+
+**Example**
+Language: ts
+Description: Read a theme cookie on the server.
+
+```ts
+import { cookies } from "next/headers";
+
+export default async function Page() {
+  const cookieStore = await cookies();
+  const theme = cookieStore.get("theme")?.value ?? "light";
+  return <div data-theme={theme}>Theme: {theme}</div>;
+}
+```
+
+#### redirect
+**Kind**
+function
+
+**Summary**
+Aborts the current server-side path and redirects the caller to another URL.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/components/redirect.d.ts
+
+```ts
+export declare function redirect(url: string, type?: RedirectType): never;
+```
+
+**Guidance**
+- Use this in Server Components, Route Handlers, or Server Actions when the response should redirect immediately.
+- Do not describe this as equivalent to `router.push()`; it is a server-aware control-flow API.
+- Remember that it never returns normally.
+
+**Example**
+Language: tsx
+Description: Redirect unauthenticated users from a server-rendered page.
+
+```tsx
+import { redirect } from "next/navigation";
+
+export default async function ProtectedPage() {
+  const user = null;
+  if (!user) {
+    redirect("/login");
+  }
+  return <div>Secret area</div>;
+}
+```
+
+#### notFound
+**Kind**
+function
+
+**Summary**
+Aborts the current render path and renders the not-found boundary.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/client/components/not-found.d.ts
+
+```ts
+export declare function notFound(): never;
+```
+
+**Guidance**
+- Use when the requested resource truly does not exist for the current route.
+- Treat this as control flow, not as a value-returning helper.
+- Keep it in server-side or route-resolution contexts rather than trying to call it from client event handlers.
+
+**Example**
+Language: tsx
+Description: Render the 404 boundary when a record lookup fails.
+
+```tsx
+import { notFound } from "next/navigation";
+
+export default async function ProductPage() {
+  const product = null;
+  if (!product) {
+    notFound();
+  }
+  return <div>{product.name}</div>;
+}
+```
+
+### Caching And Revalidation
+**Exports**
+- revalidatePath
+- revalidateTag
+- cacheLife
+
+These primitives control framework cache invalidation and cache profile behavior.
+
+#### revalidatePath
+**Kind**
+function
+
+**Summary**
+Invalidates cached data associated with a specific route path.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/server/web/spec-extension/revalidate.d.ts
+
+```ts
+export declare function revalidatePath(
+  originalPath: string,
+  type?: "layout" | "page",
+): undefined;
+```
+
+**Guidance**
+- Use this after a mutation when path-oriented cache invalidation is the right model.
+- Keep path invalidation separate from tag invalidation; choose the one that matches how data is keyed.
+- Explain stale-data problems in framework cache terms, not only in React state terms.
+
+**Example**
+Language: ts
+Description: Revalidate a dashboard page after a mutation.
+
+```ts
+import { revalidatePath } from "next/cache";
+
+export async function updateProfile() {
+  // write to the database
+  revalidatePath("/dashboard");
+}
+```
+
+#### revalidateTag
+**Kind**
+function
+
+**Summary**
+Invalidates cached data associated with a cache tag.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/server/web/spec-extension/revalidate.d.ts
+
+```ts
+export declare function revalidateTag(
+  tag: string,
+  profile: string | CacheLifeConfig,
+): undefined;
+```
+
+**Guidance**
+- Use tag invalidation when data dependencies are shared across multiple paths.
+- Keep your tag model intentional; ad hoc tags make invalidation hard to reason about.
+- Prefer tag invalidation over broad path invalidation when the data boundary is domain-specific rather than route-specific.
+
+**Example**
+Language: ts
+Description: Revalidate all cache entries tagged for a product collection.
+
+```ts
+import { revalidateTag } from "next/cache";
+
+export async function publishProduct() {
+  // write to the database
+  revalidateTag("products", "max");
+}
+```
+
+#### cacheLife
+**Kind**
+function
+
+**Summary**
+Configures cache timing behavior for `"use cache"` entries.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/cache.d.ts
+
+```ts
+export function cacheLife(profile: "default" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "max"): void;
+export function cacheLife(profile: string): void;
+export function cacheLife(profile: {
+  stale?: number;
+  revalidate?: number;
+  expire?: number;
+}): void;
+```
+
+**Guidance**
+- Use this when the task is specifically about framework cache profiles, not as a generic HTTP caching helper.
+- Keep custom profiles aligned with actual data freshness and invalidation strategy.
+- If the task is just “why is my page stale?”, start with simpler invalidation explanations before introducing custom cache-life tuning.
+
+**Example**
+Language: ts
+Description: Apply a named cache profile in a cached server function.
+
+```ts
+import { cacheLife } from "next/cache";
+
+export async function getCatalog() {
+  "use cache";
+  cacheLife("minutes");
+  return [{ id: "a", name: "Catalog item" }];
+}
+```
+
+### Route Handling And Metadata
+**Exports**
+- NextRequest
+- NextResponse
+- Metadata
+- generateMetadata
+
+These primitives cover route-handler request/response behavior and metadata generation.
+
+#### NextRequest
+**Kind**
+class
+
+**Summary**
+Framework request object used in route handlers and middleware-style server entry points.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/server.d.ts
+
+```ts
+export { NextRequest } from "next/dist/server/web/spec-extension/request";
+```
+
+**Guidance**
+- Use this in Route Handlers and middleware-style code, not in page component props.
+- Treat it as a framework request abstraction with runtime implications.
+- Keep route-handler logic separate from page rendering logic even when both touch the same domain data.
+
+**Example**
+Language: ts
+Description: Read query params inside a route handler.
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const search = request.nextUrl.searchParams.get("q");
+  return NextResponse.json({ search });
+}
+```
+
+#### NextResponse
+**Kind**
+class
+
+**Summary**
+Framework response helper for route handlers and middleware-style server responses.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/server.d.ts
+
+```ts
+export { NextResponse } from "next/dist/server/web/spec-extension/response";
+```
+
+**Guidance**
+- Use this in Route Handlers or middleware-style code when you need framework-aware response helpers.
+- Do not confuse this with React render output or page component return values.
+- Keep JSON, redirect, and header-setting behavior in handler logic rather than page components.
+
+**Example**
+Language: ts
+Description: Return JSON from a route handler.
+
+```ts
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
+```
+
+#### Metadata
+**Kind**
+type
+
+**Summary**
+TypeScript type for App Router metadata objects.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/types.d.ts
+
+```ts
+export type {
+  Metadata,
+  MetadataRoute,
+  ResolvedMetadata,
+  ResolvingMetadata,
+} from "./lib/metadata/types/metadata-interface";
+```
+
+**Guidance**
+- Use this when typing static `metadata` exports or the return type of `generateMetadata`.
+- Keep metadata generation separate from page rendering or route-handler response logic.
+- Do not model arbitrary page props as metadata just because both are page-adjacent concerns.
+
+**Example**
+Language: ts
+Description: Type a static metadata export for an App Router page.
+
+```ts
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description: "Account overview",
+};
+```
+
+#### generateMetadata
+**Kind**
+other
+
+**Summary**
+App Router file-convention function for deriving page metadata dynamically.
+
+**Definition**
+Language: typescript
+Source: https://nextjs.org/docs/app/api-reference/functions/generate-metadata
+
+```ts
+import type { Metadata, ResolvingMetadata } from "next";
+
+export async function generateMetadata(
+  { params, searchParams }: {
+    params: Promise<Record<string, string>>;
+    searchParams: Promise<Record<string, string | string[] | undefined>>;
+  },
+  parent: ResolvingMetadata,
+): Promise<Metadata>;
+```
+
+**Guidance**
+- Use this when metadata depends on route params, fetched data, or parent metadata.
+- Keep it focused on metadata concerns; do not turn it into a general data-loading substitute for the page component.
+- Align the implementation with App Router conventions rather than Pages Router head management patterns.
+
+**Example**
+Language: ts
+Description: Generate metadata from a dynamic segment.
+
+```ts
+import type { Metadata } from "next";
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> },
+): Promise<Metadata> {
+  const { slug } = await params;
+  return {
+    title: `Post: ${slug}`,
+  };
+}
+```
+
+### Pages Router Compatibility
+**Exports**
+- GetServerSideProps
+- GetStaticProps
+- GetStaticPaths
+
+These types remain important for existing `pages/` codebases and migrations.
+
+#### GetServerSideProps
+**Kind**
+type
+
+**Summary**
+Pages Router server-side rendering function type.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/types.d.ts
+
+```ts
+export type GetServerSideProps<
+  Props extends { [key: string]: any } = { [key: string]: any },
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+> = (
+  context: GetServerSidePropsContext<Params, Preview>,
+) => Promise<GetServerSidePropsResult<Props>>;
+```
+
+**Guidance**
+- Use this only in Pages Router files under `pages/`.
+- Do not mix it into `app/` answers.
+- Reach for it when the task is explicitly about existing Pages Router SSR or migration support.
+
+**Example**
+Language: ts
+Description: Fetch data per request in a Pages Router page.
+
+```ts
+import type { GetServerSideProps } from "next";
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {
+      now: new Date().toISOString(),
+    },
+  };
+};
+```
+
+#### GetStaticProps
+**Kind**
+type
+
+**Summary**
+Pages Router static generation function type.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/types.d.ts
+
+```ts
+export type GetStaticProps<
+  Props extends { [key: string]: any } = { [key: string]: any },
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+  Preview extends PreviewData = PreviewData,
+> = (
+  context: GetStaticPropsContext<Params, Preview>,
+) => Promise<GetStaticPropsResult<Props>> | GetStaticPropsResult<Props>;
+```
+
+**Guidance**
+- Use this only for Pages Router static generation.
+- Keep revalidation semantics aligned with Pages Router expectations rather than App Router cache APIs.
+- If the task is App Router-first, do not drag this in out of habit.
+
+**Example**
+Language: ts
+Description: Generate static props for a Pages Router page.
+
+```ts
+import type { GetStaticProps } from "next";
+
+export const getStaticProps: GetStaticProps = async () => {
+  return {
+    props: {
+      buildTime: new Date().toISOString(),
+    },
+    revalidate: 60,
+  };
+};
+```
+
+#### GetStaticPaths
+**Kind**
+type
+
+**Summary**
+Pages Router function type for enumerating dynamic paths during static generation.
+
+**Definition**
+Language: typescript
+Source: npm:next@16.1.6:package/dist/types.d.ts
+
+```ts
+export type GetStaticPaths<
+  Params extends ParsedUrlQuery = ParsedUrlQuery,
+> = (
+  context: GetStaticPathsContext,
+) => Promise<GetStaticPathsResult<Params>> | GetStaticPathsResult<Params>;
+```
+
+**Guidance**
+- Use this with dynamic Pages Router routes when static generation needs known paths.
+- Keep it in the Pages Router mental model; App Router uses different file conventions and generation APIs.
+- Explain fallback behavior in Pages Router terms when it matters to the task.
+
+**Example**
+Language: ts
+Description: Pre-generate two blog slugs in a Pages Router route.
+
+```ts
+import type { GetStaticPaths } from "next";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [{ params: { slug: "hello" } }, { params: { slug: "world" } }],
+    fallback: false,
+  };
+};
+```

--- a/website/static/distributions/claude/nextjs/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/nextjs/0.4.0/references/overview.md
@@ -1,0 +1,64 @@
+# Next.js Overview
+
+## Snapshot
+
+- Spec name: nextjs
+- Spec version: 0.4.0
+- Generated: 2026-03-12
+- Library version: ^16.1.6
+- Primary language: typescript
+- Homepage: https://nextjs.org/docs
+- Source set: npm:next@16.1.6 declarations, official Next.js docs pages, official Next.js API reference pages, and parse/nextjs-docs-v0.4.0.md as the intermediate documentation pack
+
+**Tags**
+- nextjs
+- react
+- app-router
+- pages-router
+- ssr
+- caching
+- routing
+
+## Purpose
+
+This pack teaches an agent to use Next.js 16 effectively across App Router, Pages Router compatibility, rendering boundaries, request helpers, caching and revalidation, and framework-specific routing behavior without collapsing those concerns into generic React advice.
+
+## Guiding Principles
+
+- Default to App Router mental models for new work unless the task is explicitly about Pages Router or migration.
+- Keep server components, client components, route handlers, server actions, and Pages Router data functions as distinct execution contexts.
+- Treat `next/navigation` hooks as Client Component APIs and `headers()` / `cookies()` / `redirect()` as server-side control or request APIs.
+- Distinguish framework caching and revalidation from ordinary React state updates.
+- Treat typed routes and TypeScript helpers as static safety aids, not runtime guarantees.
+- Keep Node.js and Edge runtime assumptions explicit when code depends on platform behavior.
+- Correct stale Router-era advice instead of blending incompatible patterns into one answer.
+
+## Boundary Notes
+
+- Primary contract sources: `npm:next@16.1.6:package/dist/client/link.d.ts`, `package/dist/client/components/navigation.d.ts`, `package/dist/client/components/redirect.d.ts`, `package/dist/client/components/not-found.d.ts`, `package/dist/server/request/headers.d.ts`, `package/dist/server/request/cookies.d.ts`, `package/cache.d.ts`, `package/server.d.ts`, and `package/dist/types.d.ts`.
+- Guidance sources: official Next.js docs pages for App Router, Server and Client Components, request helpers, metadata, caching, revalidation, and Pages Router data fetching.
+- Coverage is organized by real task shape: navigation and client hooks, server request and control APIs, caching and invalidation, route handling and metadata, and Pages Router compatibility.
+- This is a fresh pack, not a port. Its main job is to prevent stale mental models from leaking into answers, especially around App Router vs Pages Router and server vs client boundaries.
+- The strongest boundary in the pack is that generic React knowledge is not enough when Next.js routing, caching, or runtime semantics are the actual problem.
+
+## FAQ
+
+### When should an answer default to App Router instead of Pages Router?
+Default to App Router for new work unless the task explicitly references `pages/`, `getServerSideProps`, `getStaticProps`, `getStaticPaths`, or a migration scenario.
+
+### Are headers() and cookies() client-side APIs?
+No. They are server-side request helpers and should stay in Server Components, Route Handlers, Server Actions, or other server-side framework contexts.
+
+### Is redirect() the same thing as router.push()?
+No. `redirect()` is a server-side control-flow API that aborts the current path and redirects immediately. `router.push()` is a client-side navigation method.
+
+## External Resources
+
+- Next.js docs: https://nextjs.org/docs
+- App Router docs: https://nextjs.org/docs/app
+- Pages Router docs: https://nextjs.org/docs/pages
+- Link reference: https://nextjs.org/docs/app/api-reference/components/link
+- navigation hooks reference: https://nextjs.org/docs/app/api-reference/functions/use-router
+- request helpers reference: https://nextjs.org/docs/app/api-reference/functions/headers
+- caching reference: https://nextjs.org/docs/app/api-reference/functions/revalidatePath
+- Pages Router data reference: https://nextjs.org/docs/pages/api-reference/functions/get-server-side-props

--- a/website/static/distributions/claude/nextjs/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/nextjs/0.4.0/references/troubleshooting.md
@@ -1,0 +1,22 @@
+# Next.js Troubleshooting
+
+### A next/navigation hook fails because the component is on the server
+**Cause**
+`useRouter()`, `usePathname()`, and `useSearchParams()` are Client Component hooks and cannot run inside a Server Component.
+
+**Fix**
+Move the interactive logic into a Client Component boundary and pass server-fetched data down as props if needed.
+
+### Data stays stale after a server-side mutation
+**Cause**
+The write completed, but the relevant Next.js cache path or cache tag was not invalidated.
+
+**Fix**
+Choose `revalidatePath()` or `revalidateTag()` based on how the data is cached, and keep the invalidation call in the server-side mutation path.
+
+### Pages Router code was mixed into an App Router task
+**Cause**
+Stale Next.js advice or migration confusion pulled `getServerSideProps` or `getStaticProps` into an `app/` solution.
+
+**Fix**
+Reset the answer to the correct router model, then use App Router file conventions and server/client boundaries explicitly.

--- a/website/static/distributions/claude/nextjs/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/nextjs/0.4.0/references/workflows.md
@@ -1,0 +1,19 @@
+# Next.js Workflows
+
+### Build An App Router Page With A Client Island
+1. Start with a server component page in `app/` and keep data fetching on the server by default.
+2. Introduce a child Client Component only for browser interactivity or client hooks like `useRouter()` or `useSearchParams()`.
+3. Use `Link` for navigation and keep request-only helpers like `headers()` and `cookies()` on the server side.
+4. If the page reads stale data after a mutation, inspect cache invalidation and use `revalidatePath()` or `revalidateTag()` deliberately.
+
+### Revalidate Cached Data After A Mutation
+1. Decide whether the mutation invalidates a route path or a logical data tag.
+2. Perform the write in a server-side context such as a server action or route handler.
+3. Call `revalidatePath()` for route-oriented invalidation or `revalidateTag()` for shared tagged data.
+4. Verify that the data source and cache model match the invalidation strategy you chose.
+
+### Maintain A Pages Router Page Safely
+1. Confirm the task is actually about `pages/` rather than `app/`.
+2. Use `GetServerSideProps`, `GetStaticProps`, or `GetStaticPaths` only within the Pages Router model.
+3. Keep App Router APIs like `headers()` or `generateMetadata()` out of the answer unless the task is explicitly about migration boundaries.
+4. If the repo is mid-migration, explain the boundary instead of mixing incompatible patterns.

--- a/website/static/distributions/claude/playwright/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/playwright/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: playwright
+description: Use for Playwright testing, locator, tracing, and CI tasks. Helps with authoring stable tests, debugging failures, and runner configuration.
+---
+
+# Playwright
+
+Use this skill when the task is about Playwright test authoring, locator strategy, tracing, fixtures, or CI execution.
+
+## Purpose
+
+This pack teaches an agent to use Playwright Test at a senior-developer level: write resilient locator-first tests, use fixtures and projects instead of ad hoc shared setup, debug failures with traces and HTML reports, and run Playwright reliably in CI without falling back to brittle sleeps or selector hacks.
+
+## When to use this skill
+
+- stable locator and assertion design
+- fixtures, projects, and test runner setup
+- trace-based failure debugging
+- CI and report configuration
+
+## Working style
+
+- Prefer locator-based flows and web-first assertions over `ElementHandle`-heavy or sleep-based patterns.
+- Prefer user-facing locators like `getByRole`, `getByLabel`, and `getByText`; use `getByTestId` as an explicit contract when needed.
+- Treat auto-waiting and actionability as the default readiness model for interactions.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/playwright/0.4.0/manifest.json
+++ b/website/static/distributions/claude/playwright/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "playwright",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/playwright/0.4.0.md",
+  "display_name": "Playwright",
+  "description": "Use for Playwright testing, locator, tracing, and CI tasks. Helps with authoring stable tests, debugging failures, and runner configuration.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/playwright/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/playwright/0.4.0/references/api-groups.md
@@ -1,0 +1,595 @@
+# Playwright API Groups
+
+### Test Runner Core
+**Exports**
+- test
+- expect
+- defineConfig
+- devices
+
+Core Playwright Test exports for writing tests and configuring the runner.
+
+#### test
+**Kind**
+object
+
+**Summary**
+Primary Playwright Test object that defines tests and provides the built-in
+browser, page, and fixture environment.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright/types/test.d.ts`
+
+```ts
+export const test: TestType<
+  PlaywrightTestArgs & PlaywrightTestOptions,
+  PlaywrightWorkerArgs & PlaywrightWorkerOptions
+>;
+```
+
+**Guidance**
+- Use this as the root authoring surface for tests, hooks, fixture extension, and per-file configuration.
+- Keep tests meaning-oriented and let fixtures or projects establish environment differences.
+- Avoid manually bootstrapping browser/page lifecycle when `test` already provides the correct isolation model.
+
+**Example**
+Language: typescript
+Description: Basic Playwright test with the built-in `page` fixture.
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('homepage loads', async ({ page }) => {
+  await page.goto('https://playwright.dev');
+  await expect(page).toHaveTitle(/Playwright/);
+});
+```
+
+#### expect
+**Kind**
+object
+
+**Summary**
+Assertion surface for generic, async web-first, soft, and polling assertions.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright/types/test.d.ts`
+
+```ts
+export const expect: Expect<{}>;
+```
+
+**Guidance**
+- Prefer async locator and page assertions for UI state because they auto-retry.
+- Use `expect.poll` or `expect.toPass` for retried non-locator checks instead of ad hoc loops.
+- Treat `expect.soft` as a deliberate reporting choice, not as a blanket default.
+
+**Example**
+Language: typescript
+Description: Web-first assertion that waits until the DOM reflects the expected text.
+
+```ts
+await expect(page.getByTestId('status')).toHaveText('Submitted');
+```
+
+#### defineConfig
+**Kind**
+function
+
+**Summary**
+Type-safe helper for declaring Playwright Test configuration.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright/types/test.d.ts`
+
+```ts
+export function defineConfig(config: PlaywrightTestConfig): PlaywrightTestConfig;
+export function defineConfig(config: PlaywrightTestConfig, ...configs: PlaywrightTestConfig[]): PlaywrightTestConfig;
+```
+
+**Guidance**
+- Centralize shared defaults here instead of scattering timeouts, retries, projects, and `use` values across test files.
+- Keep environment-specific or browser-specific behavior inside `projects`.
+- Use the config to codify the team’s debugging posture, including traces and reporter output.
+
+**Example**
+Language: typescript
+Description: Minimal config with CI-aware retries and tracing.
+
+```ts
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+#### devices
+**Kind**
+object
+
+**Summary**
+Registry of desktop and mobile browser/device presets for project configuration.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright-core/types/types.d.ts`
+
+```ts
+export const devices: Devices;
+```
+
+**Guidance**
+- Use this to configure browser and mobile presets in `projects` instead of hand-building device emulation objects when an official preset exists.
+- Prefer named device presets for readability and consistency across suites.
+- Treat device presets as browser-context defaults, not as a replacement for app-specific test data or auth setup.
+
+**Example**
+Language: typescript
+Description: Use an official device preset in a project definition.
+
+```ts
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+  ],
+});
+```
+
+### Locators and Web-First Assertions
+**Exports**
+- page.getByRole
+- page.getByTestId
+- locator.filter
+- web-first assertions
+
+The core anti-flakiness surface: user-facing locators plus auto-retrying
+assertions.
+
+#### page.getByRole
+**Kind**
+function
+
+**Summary**
+Create a locator by ARIA role and optional accessible-name and state filters.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright-core/types/types.d.ts`
+
+```ts
+getByRole(
+  role: string,
+  options?: {
+    name?: string | RegExp;
+    exact?: boolean;
+    checked?: boolean;
+    disabled?: boolean;
+    expanded?: boolean;
+    includeHidden?: boolean;
+    level?: number;
+    pressed?: boolean;
+    selected?: boolean;
+  }
+): Locator;
+```
+
+**Guidance**
+- Prefer this when the element has a meaningful user-facing role and name.
+- Usually pass the accessible name so the locator stays specific and readable.
+- This is the preferred first-choice locator for most interactive UI testing.
+
+**Example**
+Language: typescript
+Description: Click the submit button by role and accessible name.
+
+```ts
+await page.getByRole('button', { name: /submit/i }).click();
+```
+
+#### page.getByTestId
+**Kind**
+function
+
+**Summary**
+Create a locator from the configured test-id attribute.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright-core/types/types.d.ts`
+
+```ts
+getByTestId(testId: string | RegExp): Locator;
+```
+
+**Guidance**
+- Use this when your app intentionally provides a stable testing contract.
+- Prefer role/name locators first when the UI already exposes good accessible semantics.
+- If you customize the test-id attribute, do it centrally in config instead of mixing attributes across files.
+
+**Example**
+Language: typescript
+Description: Locate a status node by explicit testing contract.
+
+```ts
+await expect(page.getByTestId('status')).toHaveText('Submitted');
+```
+
+#### locator.filter
+**Kind**
+function
+
+**Summary**
+Narrow an existing locator by nested locators or text conditions.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright-core/types/types.d.ts`
+
+```ts
+filter(options?: {
+  has?: Locator;
+  hasNot?: Locator;
+  hasText?: string | RegExp;
+  hasNotText?: string | RegExp;
+}): Locator;
+```
+
+**Guidance**
+- Use this when a base locator is right structurally but still too broad.
+- Prefer filtering relative to a strong base locator instead of building fragile long CSS selectors.
+- Keep inner locators frame-relative and in the same frame as the outer locator.
+
+**Example**
+Language: typescript
+Description: Narrow rows to the one that contains both text and a nested button.
+
+```ts
+const row = page
+  .locator('tr')
+  .filter({ hasText: 'Ada Lovelace' })
+  .filter({ has: page.getByRole('button', { name: 'Edit' }) });
+```
+
+#### web-first assertions
+**Kind**
+workflow
+
+**Summary**
+Auto-retrying async assertions that wait for dynamic UI state instead of reading
+the page once and guessing timing manually.
+
+**Definition**
+Language: markdown
+Source: `docs/src/test-assertions-js.md` and `docs/src/actionability.md`
+
+```md
+await expect(locator).toBeVisible();
+await expect(locator).toHaveText('Submitted');
+await expect(page).toHaveURL(/dashboard/);
+```
+
+**Guidance**
+- Prefer these over manual `waitForTimeout`, repeated `isVisible` loops, or brittle “sleep then assert” patterns.
+- They work best when paired with strong locators.
+- The default assertion timeout is 5 seconds unless changed in config.
+
+**Example**
+Language: typescript
+Description: Wait for a status change without manual polling.
+
+```ts
+await expect(page.getByRole('status')).toHaveText('Saved');
+```
+
+### Fixtures and Project Configuration
+**Exports**
+- built-in fixtures
+- test.extend
+- projects
+- project dependencies
+
+Reusable environment modeling for browsers, auth, page objects, and CI/browser
+matrices.
+
+#### built-in fixtures
+**Kind**
+workflow
+
+**Summary**
+The built-in test-time environment objects Playwright injects, such as `page`,
+`context`, `browser`, `browserName`, and `request`.
+
+**Definition**
+Language: markdown
+Source: `docs/src/test-fixtures-js.md`
+
+```md
+Most common built-in fixtures:
+- page
+- context
+- browser
+- browserName
+- request
+```
+
+**Guidance**
+- Treat `page` as isolated per test and `browser` as shared for efficiency.
+- Use fixtures to give tests exactly what they need and nothing else.
+- Reach for custom fixtures before copy-pasting `beforeEach` setup across many files.
+
+**Example**
+Language: typescript
+Description: Use the built-in `request` and `page` fixtures in one test.
+
+```ts
+test('healthcheck and UI', async ({ request, page }) => {
+  const response = await request.get('/health');
+  await expect(response).toBeOK();
+  await page.goto('/');
+});
+```
+
+#### test.extend
+**Kind**
+function
+
+**Summary**
+Extend the base `test` object with custom fixtures and test options.
+
+**Definition**
+Language: typescript
+Source: `packages/playwright/types/test.d.ts`
+
+```ts
+extend<T extends {}, W extends {} = {}>(
+  fixtures: Fixtures<T, W, TestArgs, WorkerArgs>
+): TestType<TestArgs & T, WorkerArgs & W>;
+```
+
+**Guidance**
+- Use this for reusable page objects, authenticated contexts, seeded data, or test options.
+- Prefer fixtures over matching `beforeEach`/`afterEach` hooks scattered across many files.
+- Keep fixture scope intentional so setup does not leak state between unrelated tests.
+
+**Example**
+Language: typescript
+Description: Extend the base test with a reusable page-object fixture.
+
+```ts
+import { test as base } from '@playwright/test';
+
+export const test = base.extend<{ todoPage: TodoPage }>({
+  todoPage: async ({ page }, use) => {
+    const todoPage = new TodoPage(page);
+    await todoPage.goto();
+    await use(todoPage);
+  },
+});
+```
+
+#### projects
+**Kind**
+config
+
+**Summary**
+Logical groups of tests that run with different browser, device, environment, or
+retry settings.
+
+**Definition**
+Language: typescript
+Source: `docs/src/test-projects-js.md`
+
+```ts
+export default defineConfig({
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});
+```
+
+**Guidance**
+- Use projects for browsers, environments, or focused subsets like smoke tests.
+- Keep shared defaults at the top-level config and project-specific overrides inside each project.
+- Use `--project` when debugging one configuration instead of disabling the rest in source.
+
+**Example**
+Language: bash
+Description: Run a single configured project.
+
+```bash
+npx playwright test --project=firefox
+```
+
+#### project dependencies
+**Kind**
+config
+
+**Summary**
+Project-level setup sequencing where one project must complete before dependent
+projects run.
+
+**Definition**
+Language: typescript
+Source: `docs/src/test-projects-js.md`
+
+```ts
+export default defineConfig({
+  projects: [
+    { name: 'setup', testMatch: '**/*.setup.ts' },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+    },
+  ],
+});
+```
+
+**Guidance**
+- Use this when browser projects depend on setup tests that should also produce traces and reporter output.
+- Prefer project dependencies over bespoke global shell scripts when the setup itself is meaningfully test-like.
+- If a dependency fails, dependents will not run; model your setup project accordingly.
+
+**Example**
+Language: text
+Description: Use a setup project to establish shared auth or data before browser projects run.
+
+```text
+Create a setup project, then list it in each dependent project's dependencies array.
+```
+
+### Tracing, Reports, and CI
+**Exports**
+- use.trace
+- npx playwright show-report
+- npx playwright show-trace
+- GitHub Actions workflow
+
+Operational debugging and CI delivery surface for Playwright suites.
+
+#### use.trace
+**Kind**
+config
+
+**Summary**
+Per-test tracing configuration, commonly enabled on the first retry in CI.
+
+**Definition**
+Language: typescript
+Source: `docs/src/trace-viewer-intro-js.md`
+
+```ts
+export default defineConfig({
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    trace: 'on-first-retry',
+  },
+});
+```
+
+**Guidance**
+- `on-first-retry` is the documented default posture because it captures failures without tracing every passing test.
+- Use `--trace on` locally when you need traces immediately outside UI Mode.
+- Make sure retries and trace settings align, or you may expect traces that were never recorded.
+
+**Example**
+Language: bash
+Description: Force tracing locally for a run.
+
+```bash
+npx playwright test --trace on
+```
+
+#### npx playwright show-report
+**Kind**
+workflow
+
+**Summary**
+Open the HTML report for the most recent test run.
+
+**Definition**
+Language: bash
+Source: `docs/src/trace-viewer-intro-js.md`
+
+```bash
+npx playwright show-report
+```
+
+**Guidance**
+- Use this first when a run failed and you need a structured view of failing tests, steps, and traces.
+- The HTML report is also the main entry point to opening trace artifacts from a failed test.
+- Keep the report artifact on CI when remote debugging matters.
+
+**Example**
+Language: bash
+Description: Open the HTML report after a failed local run.
+
+```bash
+npx playwright show-report
+```
+
+#### npx playwright show-trace
+**Kind**
+workflow
+
+**Summary**
+Open Trace Viewer directly against a trace artifact or an empty viewer session.
+
+**Definition**
+Language: bash
+Source: `docs/src/test-cli-js.md` and `docs/src/trace-viewer-intro-js.md`
+
+```bash
+npx playwright show-trace
+npx playwright show-trace trace.zip
+```
+
+**Guidance**
+- Use this when you already know which trace artifact you want to inspect.
+- Prefer this for deep step-by-step debugging of one failure rather than scanning the entire HTML report.
+- Pair it with `use.trace` and CI artifact retention so the trace actually exists when you need it.
+
+**Example**
+Language: bash
+Description: Inspect a single trace artifact.
+
+```bash
+npx playwright show-trace trace.zip
+```
+
+#### GitHub Actions workflow
+**Kind**
+workflow
+
+**Summary**
+Reference CI workflow for running Playwright on GitHub Actions with browser
+installation and report artifact upload.
+
+**Definition**
+Language: yaml
+Source: `docs/src/ci-intro.md`
+
+```yml
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
+    - run: npm ci
+    - run: npx playwright install --with-deps
+    - run: npx playwright test
+```
+
+**Guidance**
+- Install Playwright browsers explicitly on CI; installing the npm package alone is not enough.
+- Upload the HTML report or trace artifacts so failures are debuggable from the CI UI.
+- Keep retries, tracing, and artifact retention aligned with how your team debugs flakes.
+
+**Example**
+Language: text
+Description: Minimal CI checklist.
+
+```text
+checkout repo -> install node deps -> install playwright browsers with deps -> run tests -> upload report artifacts
+```

--- a/website/static/distributions/claude/playwright/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/playwright/0.4.0/references/overview.md
@@ -1,0 +1,74 @@
+# Playwright Overview
+
+## Snapshot
+
+- Spec name: playwright
+- Spec version: 0.4.0
+- Generated: 2026-03-15
+- Library version: @playwright/test^1.58.2
+- Primary language: typescript
+- Homepage: https://playwright.dev
+- Source set: stable `release-1.58` branch of `microsoft/playwright`; `packages/playwright-test/package.json`; `packages/playwright/types/test.d.ts`; `packages/playwright-core/types/types.d.ts`; `README.md`; `docs/src/locators.md`; `docs/src/actionability.md`; `docs/src/test-fixtures-js.md`; `docs/src/test-assertions-js.md`; `docs/src/trace-viewer-intro-js.md`; `docs/src/ci-intro.md`; `docs/src/test-projects-js.md`; and `parse/playwright-docs-v0.4.0.md`
+
+**Tags**
+- playwright
+- testing
+- e2e
+- fixtures
+- locators
+- ci
+
+## Purpose
+
+This pack teaches an agent to use Playwright Test at a senior-developer level:
+write resilient locator-first tests, use fixtures and projects instead of ad hoc
+shared setup, debug failures with traces and HTML reports, and run Playwright
+reliably in CI without falling back to brittle sleeps or selector hacks.
+
+## Guiding Principles
+
+- Prefer locator-based flows and web-first assertions over `ElementHandle`-heavy or sleep-based patterns.
+- Prefer user-facing locators like `getByRole`, `getByLabel`, and `getByText`; use `getByTestId` as an explicit contract when needed.
+- Treat auto-waiting and actionability as the default readiness model for interactions.
+- Use fixtures to encapsulate reusable setup and teardown.
+- Use projects for browser matrices, environment variants, and setup dependencies.
+- Capture traces and HTML reports as the default debugging surface for failures, especially on CI.
+- Treat `force: true` as an escape hatch, not a first-line fix for flakiness.
+- Keep the pack aligned to stable `@playwright/test^1.58.2`, not the `next` branch.
+
+## Boundary Notes
+
+- This pack targets the JavaScript and TypeScript Playwright Test runner surface, not every language binding.
+- The stable npm line is `1.58.2`, and upstream `main` is already on `1.59.0-next`, so source selection is locked to the stable `release-1.58` branch and stable docs.
+- The official docs strongly center locators, actionability, fixtures, assertions, traces, projects, and CI as the main anti-flakiness model; this pack keeps that emphasis instead of trying to document every browser primitive.
+- Type definitions in `packages/playwright/types/test.d.ts` and `packages/playwright-core/types/types.d.ts` are used as the authoritative contract source for exported JS/TS symbols.
+
+## FAQ
+
+### Should I use `getByRole` or `getByTestId` first?
+Use `getByRole` first when the element has meaningful accessible semantics. Use
+`getByTestId` when your app intentionally provides a stable testing contract or
+the UI surface is otherwise difficult to express robustly.
+
+### Are fixtures better than hooks?
+For reusable environment setup, usually yes. Fixtures encapsulate setup and
+teardown together, are on-demand, and compose better across files.
+
+### Is `waitForTimeout` a normal anti-flakiness tool?
+No. It is usually a smell. Prefer actionability, locator-based interactions, and
+web-first assertions.
+
+### When should I use traces?
+Use traces when debugging failures, especially on CI. `on-first-retry` is the
+common default because it captures failure context without tracing every passing test.
+
+## External Resources
+
+- Playwright docs: https://playwright.dev/docs/intro
+- Playwright API reference: https://playwright.dev/docs/api/class-playwright
+- Playwright GitHub repo: https://github.com/microsoft/playwright
+- Locator guide: https://playwright.dev/docs/locators
+- Assertions guide: https://playwright.dev/docs/test-assertions
+- Fixtures guide: https://playwright.dev/docs/test-fixtures
+- Trace viewer guide: https://playwright.dev/docs/trace-viewer
+- CI guide: https://playwright.dev/docs/ci

--- a/website/static/distributions/claude/playwright/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/playwright/0.4.0/references/troubleshooting.md
@@ -1,0 +1,37 @@
+# Playwright Troubleshooting
+
+### The test is flaky even though the selector looks correct
+**Cause**
+The test is relying on brittle selectors, manual sleeps, or non-retrying assertions
+instead of locator-first interactions and web-first assertions.
+
+**Fix**
+Switch to user-facing locators like `getByRole`, `getByLabel`, or `getByTestId`
+and use async `expect(...)` assertions that retry until the UI settles.
+
+### `force: true` makes the click pass, but the failure keeps returning
+**Cause**
+The underlying actionability issue was bypassed instead of understood, so the
+test still interacts with an element that is obscured, disabled, unstable, or
+not uniquely resolved.
+
+**Fix**
+Inspect the trace or action log, tighten the locator, and wait for the actual UI
+state that makes the action valid.
+
+### CI says Playwright is installed, but browsers are missing
+**Cause**
+The npm package was installed, but Playwright browsers and system dependencies
+were not installed on the CI runner.
+
+**Fix**
+Run `npx playwright install --with-deps` in the CI workflow before running the tests.
+
+### The expected trace is missing
+**Cause**
+Retries or `use.trace` were never configured, so the failure did not produce a
+trace artifact.
+
+**Fix**
+Enable CI-aware retries and set `use.trace` to `on-first-retry` or a stricter
+mode, then retain the artifacts.

--- a/website/static/distributions/claude/playwright/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/playwright/0.4.0/references/workflows.md
@@ -1,0 +1,25 @@
+# Playwright Workflows
+
+### Start a New Playwright Test Suite
+1. Install `@playwright/test` and Playwright browsers.
+2. Create `playwright.config.ts` with shared defaults for retries, traces, and projects.
+3. Write tests with `test` plus locator-first interactions and web-first assertions.
+4. Prefer role- and label-based locators before falling back to test IDs.
+
+### Build Reusable Page Objects and Auth Setup
+1. Start from built-in fixtures like `page` and `request`.
+2. Use `test.extend` for reusable page objects, authenticated contexts, or seeded environment setup.
+3. Keep fixture setup and teardown co-located instead of duplicating hooks.
+4. Use projects or setup dependencies when a setup phase should run before multiple browser projects.
+
+### Debug a Flaky Failure
+1. Re-check the locator choice before changing timing.
+2. Replace manual sleeps with web-first assertions where possible.
+3. Record or open traces with `use.trace`, `show-report`, or `show-trace`.
+4. Treat `force: true` as a last resort after understanding why actionability did not pass.
+
+### Run Playwright on CI
+1. Install Node dependencies.
+2. Install Playwright browsers with `npx playwright install --with-deps`.
+3. Run the suite through the configured projects.
+4. Upload HTML reports and traces as artifacts so failures are inspectable after the run.

--- a/website/static/distributions/claude/react/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/react/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: react
+description: Use for React component, hooks, rendering, and performance tasks. Helps with API usage, debugging, and implementation decisions.
+---
+
+# React
+
+Use this skill when the task depends on React-specific component, hooks, rendering, or performance behavior and generic JavaScript advice is not enough.
+
+## Purpose
+
+This pack teaches an agent to use React's core public API for component composition, state, effects, concurrency, and performance-sensitive rendering tasks in a React 18.3-era codebase.
+
+## When to use this skill
+
+- component architecture and composition
+- hooks usage, lifecycle, and state management
+- rendering performance and responsiveness issues
+- framework-specific migration and debugging
+
+## Working style
+
+- Prefer current function-component and hooks-based patterns over legacy class APIs.
+- Treat TypeScript signatures as the authoritative contract for each symbol.
+- Keep dependency arrays complete and use linting rules to enforce them.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/react/0.4.0/manifest.json
+++ b/website/static/distributions/claude/react/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "react",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/react/0.4.0.md",
+  "display_name": "React",
+  "description": "Use for React component, hooks, rendering, and performance tasks. Helps with API usage, debugging, and implementation decisions.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/react/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/react/0.4.0/references/api-groups.md
@@ -1,0 +1,912 @@
+# React API Groups
+
+### Element Creation
+**Exports**
+- createElement
+- cloneElement
+- Fragment
+
+Core factories and primitives for producing or reshaping React elements.
+
+#### createElement
+**Kind**
+function
+
+**Summary**
+Programmatically creates a React element from a type, props object, and children.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function createElement<P extends {}>(
+    type: FunctionComponent<P> | ComponentClass<P> | string,
+    props?: Attributes & P | null,
+    ...children: ReactNode[]
+): ReactElement<P>;
+```
+
+**Guidance**
+- Prefer JSX for everyday component authoring and reserve `createElement` for meta-frameworks, dynamic component factories, or non-JSX transforms.
+- Supply stable `key` props when producing elements inside arrays so React can preserve identity correctly.
+- The `type` parameter accepts intrinsic element names or component references; ensure the props object matches the chosen target.
+
+**Example**
+Language: javascript
+
+```js
+import React from "react";
+
+const button = React.createElement(
+  "button",
+  { type: "button", onClick: () => alert("Hi") },
+  "Click me"
+);
+
+export default function App() {
+  return button;
+}
+```
+
+#### cloneElement
+**Kind**
+function
+
+**Summary**
+Copies an existing React element while overriding props and optional children.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function cloneElement<P>(
+    element: ReactElement<P>,
+    props?: Partial<P> & Attributes,
+    ...children: ReactNode[]
+): ReactElement<P>;
+```
+
+**Guidance**
+- Use `cloneElement` when you need to inject props into child elements you do not own directly, such as slot-like children passed through props.
+- Be deliberate with `key` and `ref`; passing replacements changes identity or ref wiring.
+- Prefer simpler composition patterns when possible, because cloning can obscure the data flow.
+
+**Example**
+Language: javascript
+
+```js
+import React, { cloneElement } from "react";
+
+function AddClass({ child }) {
+  if (!React.isValidElement(child)) {
+    return child;
+  }
+
+  return cloneElement(child, { className: "highlight" });
+}
+```
+
+#### Fragment
+**Kind**
+component
+
+**Summary**
+Groups multiple children without introducing an extra DOM element.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+const Fragment: FunctionComponent<{ children?: ReactNode | undefined }>;
+```
+
+**Guidance**
+- Use the `<>...</>` shorthand by default and reach for `<Fragment>` when you need to attach a `key`.
+- Keys belong on the fragment when mapping lists of fragment groups.
+- Fragment is structural only; it does not change layout or accessibility semantics.
+
+**Example**
+Language: javascript
+
+```js
+import { Fragment } from "react";
+
+function List({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <Fragment key={item.id}>
+          <li>{item.label}</li>
+          <li>{item.detail}</li>
+        </Fragment>
+      ))}
+    </ul>
+  );
+}
+```
+
+### Component Helpers
+**Exports**
+- Children
+- memo
+- forwardRef
+- lazy
+- Suspense
+
+Helpers for working with children, stable component identities, refs, and code-splitting boundaries.
+
+#### Children
+**Kind**
+object
+
+**Summary**
+Provides utilities for counting, mapping, and normalizing the opaque `props.children` structure.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+interface ReactChildren {
+    map<T, C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => T): Array<...>;
+    forEach<C>(children: C | ReadonlyArray<C>, fn: (child: C, index: number) => void): void;
+    count(children: any): number;
+    only<C>(children: C): C;
+    toArray(children: ReactNode | ReactNode[]): Array<...>;
+}
+const Children: ReactChildren;
+```
+
+**Guidance**
+- Use `Children.map` and `Children.toArray` when the caller may pass a single child, nested fragments, or falsy children.
+- `Children.only` is useful for APIs that require exactly one child and should fail fast when the contract is violated.
+- Normalizing children through `toArray` helps with stable key handling before rendering.
+
+**Example**
+Language: javascript
+
+```js
+import { Children } from "react";
+
+function Upper({ children }) {
+  return Children.map(children, (child) =>
+    typeof child === "string" ? child.toUpperCase() : child
+  );
+}
+```
+
+#### memo
+**Kind**
+function
+
+**Summary**
+Wraps a component in shallow prop comparison to skip unnecessary re-renders.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function memo<P extends object>(
+    Component: FunctionComponent<P>,
+    propsAreEqual?: (prevProps: Readonly<P>, nextProps: Readonly<P>) => boolean
+): NamedExoticComponent<P>;
+```
+
+**Guidance**
+- Use `memo` when a child re-renders frequently with stable props and the skipped work is meaningful.
+- Pair `memo` with stable object, array, and callback references from the parent; otherwise the shallow comparison will miss.
+- Prefer the default shallow comparison unless there is a clear, measured reason to provide a custom comparator.
+
+**Example**
+Language: javascript
+
+```js
+import { memo } from "react";
+
+const Row = memo(
+  function Row({ item }) {
+    return <div>{item.text}</div>;
+  },
+  (prev, next) => prev.item.id === next.item.id
+);
+
+export default Row;
+```
+
+#### forwardRef
+**Kind**
+function
+
+**Summary**
+Allows a function component to receive a ref and forward it to an inner element or component.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function forwardRef<T, P = {}>(
+    render: ForwardRefRenderFunction<T, P>
+): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+```
+
+**Guidance**
+- Use `forwardRef` for reusable primitives such as inputs, buttons, and focusable controls that need imperative access from parents.
+- Keep the forwarded ref attached to the final public target element or pair it with `useImperativeHandle` to expose a narrowed imperative API.
+- Do not add ref forwarding by default if the component has no legitimate imperative use case.
+
+**Example**
+Language: javascript
+
+```js
+import { forwardRef } from "react";
+
+const FancyInput = forwardRef(function FancyInput(props, ref) {
+  return <input ref={ref} {...props} />;
+});
+```
+
+#### lazy
+**Kind**
+function
+
+**Summary**
+Declares a lazily loaded component backed by a dynamic `import()`.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function lazy<T extends ComponentType<any>>(
+    factory: () => Promise<{ default: T }>
+): LazyExoticComponent<T>;
+```
+
+**Guidance**
+- Ensure the imported module exposes a default export that resolves to the component.
+- Always render lazy components inside a `Suspense` boundary with an appropriate fallback.
+- Use lazy loading for routes or heavy components where bundle splitting improves startup or interaction costs.
+
+**Example**
+Language: javascript
+
+```js
+import { lazy, Suspense } from "react";
+
+const Chart = lazy(() => import("./Chart"));
+
+export default function Dashboard() {
+  return (
+    <Suspense fallback={<p>Loading chart...</p>}>
+      <Chart />
+    </Suspense>
+  );
+}
+```
+
+#### Suspense
+**Kind**
+component
+
+**Summary**
+Defines a boundary that shows fallback UI while child components or data dependencies suspend.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+const Suspense: ExoticComponent<SuspenseProps>;
+interface SuspenseProps {
+    children?: ReactNode;
+    fallback?: NonNullable<ReactNode> | null;
+}
+```
+
+**Guidance**
+- Place `Suspense` around lazy components or data-aware children that can suspend, and pick fallbacks that match the scope of the pending work.
+- Nest boundaries to create progressive loading sequences instead of one global spinner for the whole page.
+- Keep fallbacks lightweight and structurally close to the pending content to minimize UI jumpiness.
+
+**Example**
+Language: javascript
+
+```js
+import { Suspense } from "react";
+import ProfileDetails from "./ProfileDetails";
+import ProfileTimeline from "./ProfileTimeline";
+
+export default function Profile() {
+  return (
+    <Suspense fallback={<div>Fetching profile...</div>}>
+      <ProfileDetails />
+      <Suspense fallback={<div>Fetching timeline...</div>}>
+        <ProfileTimeline />
+      </Suspense>
+    </Suspense>
+  );
+}
+```
+
+### Core Hooks
+**Exports**
+- useState
+- useEffect
+- useContext
+- useReducer
+- useRef
+
+State, effects, context consumption, reducer-driven state transitions, and mutable references.
+
+#### useState
+**Kind**
+hook
+
+**Summary**
+Declares component-local state and returns the current value with a setter.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useState<S>(initialState: S | (() => S)): [S, Dispatch<SetStateAction<S>>];
+function useState<S = undefined>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>];
+```
+
+**Guidance**
+- Use lazy initialization when computing the initial value is expensive.
+- Use functional updates when the next state depends on the previous state.
+- Split unrelated state into separate hooks when it improves update locality and readability.
+
+**Example**
+Language: javascript
+
+```js
+import { useState } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button onClick={() => setCount((current) => current + 1)}>
+      {count}
+    </button>
+  );
+}
+```
+
+#### useEffect
+**Kind**
+hook
+
+**Summary**
+Synchronizes rendered output with external systems such as subscriptions, network activity, and DOM integration.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useEffect(effect: EffectCallback, deps?: DependencyList): void;
+```
+
+**Guidance**
+- Include every reactive value used inside the effect in the dependency array.
+- Return cleanup logic whenever the effect creates subscriptions, timers, listeners, or in-flight work that must be torn down.
+- Prefer event handlers or derived render logic over effects when no external synchronization is needed.
+
+**Example**
+Language: javascript
+
+```js
+import { useEffect, useState } from "react";
+
+function UserProfile({ userId }) {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/user/${userId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (!cancelled) setUser(data);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return <div>{user ? user.name : "Loading..."}</div>;
+}
+```
+
+#### useContext
+**Kind**
+hook
+
+**Summary**
+Reads the nearest current value for a given React context.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useContext<T>(context: Context<T>): T;
+```
+
+**Guidance**
+- Pass the context object itself, not a provider or the context value.
+- Consumers re-render when the provided value changes, so memoize object-like provider values when necessary.
+- Use context for tree-wide coordination, not as a default replacement for every prop.
+
+**Example**
+Language: javascript
+
+```js
+import { createContext, useContext } from "react";
+
+const ThemeContext = createContext("light");
+
+function ThemedButton() {
+  const theme = useContext(ThemeContext);
+  return <button className={`btn-${theme}`}>Click</button>;
+}
+```
+
+#### useReducer
+**Kind**
+hook
+
+**Summary**
+Manages state transitions through a reducer and dispatched actions.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useReducer<R extends Reducer<any, any>>(
+    reducer: R,
+    initialState: ReducerState<R>,
+    initializer?: undefined
+): [ReducerState<R>, Dispatch<ReducerAction<R>>];
+```
+
+**Guidance**
+- Prefer `useReducer` when transitions are complex, state fields are coupled, or updates are easiest to express as actions.
+- Keep reducers pure and move side effects out into event handlers or effects.
+- Use explicit action shapes so the reducer remains auditable and easy to extend.
+
+**Example**
+Language: javascript
+
+```js
+import { useReducer } from "react";
+
+const initialState = { count: 0 };
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "increment":
+      return { count: state.count + 1 };
+    default:
+      throw new Error(`Unknown action: ${action.type}`);
+  }
+}
+
+export default function Counter() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return <button onClick={() => dispatch({ type: "increment" })}>{state.count}</button>;
+}
+```
+
+#### useRef
+**Kind**
+hook
+
+**Summary**
+Creates a stable mutable container whose `.current` value persists across renders without triggering re-renders.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useRef<T>(initialValue: T): MutableRefObject<T>;
+function useRef<T>(initialValue: T | null): RefObject<T>;
+```
+
+**Guidance**
+- Use refs for DOM access, instance-like mutable values, and previous-value storage that should not affect rendering.
+- Update refs from effects or event handlers rather than during render.
+- Do not treat refs as reactive state; changing `.current` does not schedule a render.
+
+**Example**
+Language: javascript
+
+```js
+import { useEffect, useRef } from "react";
+
+export default function FocusOnMount() {
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return <input ref={inputRef} />;
+}
+```
+
+### Performance Hooks
+**Exports**
+- useCallback
+- useMemo
+- useLayoutEffect
+- useTransition
+- startTransition
+
+Tools for reference stability, expensive computations, synchronous layout work, and concurrent non-urgent updates.
+
+#### useCallback
+**Kind**
+hook
+
+**Summary**
+Memoizes a callback so its function identity stays stable until dependencies change.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useCallback<T extends (...args: any[]) => any>(
+    callback: T,
+    deps: DependencyList
+): T;
+```
+
+**Guidance**
+- Use `useCallback` when a stable function identity materially reduces downstream work or stabilizes another hook dependency.
+- Dependency rules are the same as `useEffect`; include every reactive value used inside the callback.
+- Do not add `useCallback` automatically when the downstream consumer does not care about function identity.
+
+**Example**
+Language: javascript
+
+```js
+import { memo, useCallback, useState } from "react";
+
+const Child = memo(function Child({ onClick }) {
+  return <button onClick={onClick}>Click</button>;
+});
+
+export default function Parent() {
+  const [count, setCount] = useState(0);
+  const handleClick = useCallback(() => {
+    console.log("clicked");
+  }, []);
+
+  return (
+    <>
+      <button onClick={() => setCount((current) => current + 1)}>{count}</button>
+      <Child onClick={handleClick} />
+    </>
+  );
+}
+```
+
+#### useMemo
+**Kind**
+hook
+
+**Summary**
+Memoizes a computed value and recomputes it only when dependencies change.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useMemo<T>(factory: () => T, deps: DependencyList | undefined): T;
+```
+
+**Guidance**
+- Use `useMemo` for expensive derived values or to stabilize object and array identities passed into memoized consumers.
+- Keep the dependency list accurate so the memoized value stays synchronized with inputs.
+- Avoid it for cheap calculations because memoization adds its own maintenance cost.
+
+**Example**
+Language: javascript
+
+```js
+import { useMemo } from "react";
+
+function SortedList({ list, sortFn }) {
+  const sortedList = useMemo(() => [...list].sort(sortFn), [list, sortFn]);
+
+  return <ul>{sortedList.map((item) => <li key={item}>{item}</li>)}</ul>;
+}
+```
+
+#### useLayoutEffect
+**Kind**
+hook
+
+**Summary**
+Runs an effect synchronously after DOM mutation and before the browser paints.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useLayoutEffect(effect: EffectCallback, deps?: DependencyList): void;
+```
+
+**Guidance**
+- Prefer `useEffect` unless you need layout measurement or synchronous DOM correction before paint.
+- Keep work inside `useLayoutEffect` small because it blocks painting.
+- Use it for measurement-driven positioning or visual adjustments that would otherwise flicker.
+
+**Example**
+Language: javascript
+
+```js
+import { useLayoutEffect, useRef, useState } from "react";
+
+function MeasureElement() {
+  const ref = useRef(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    if (ref.current) {
+      setWidth(ref.current.offsetWidth);
+    }
+  }, []);
+
+  return <div ref={ref}>My width is: {width}px</div>;
+}
+```
+
+#### useTransition
+**Kind**
+hook
+
+**Summary**
+Marks state updates as non-urgent transitions and exposes pending state.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useTransition(): [boolean, TransitionStartFunction];
+```
+
+**Guidance**
+- Use the returned `startTransition` for updates whose results can lag behind urgent input or cursor movement.
+- Read `isPending` to surface loading or in-progress UI during the transition.
+- Keep urgent state such as the current input value outside the transition and defer the expensive downstream work.
+
+**Example**
+Language: javascript
+
+```js
+import { useState, useTransition } from "react";
+
+function SearchComponent({ data }) {
+  const [query, setQuery] = useState("");
+  const [inputValue, setInputValue] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  function handleChange(event) {
+    const value = event.target.value;
+    setInputValue(value);
+    startTransition(() => {
+      setQuery(value);
+    });
+  }
+
+  return (
+    <>
+      <input value={inputValue} onChange={handleChange} />
+      {isPending ? <p>Filtering...</p> : <List query={query} data={data} />}
+    </>
+  );
+}
+```
+
+**Since**
+18.0.0
+
+#### startTransition
+**Kind**
+function
+
+**Summary**
+Triggers a transition outside of the `useTransition` hook API.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function startTransition(scope: () => void): void;
+```
+
+**Guidance**
+- Use `startTransition` from event handlers or utility layers when a hook-local `isPending` value is unnecessary.
+- Wrap only the non-urgent state updates inside the provided callback.
+- If you need pending state for UI, prefer `useTransition` instead.
+
+**Example**
+Language: javascript
+
+```js
+import { startTransition } from "react";
+
+function navigateTo(url, setHistory) {
+  startTransition(() => {
+    setHistory((previous) => [...previous, url]);
+  });
+}
+```
+
+**Since**
+18.0.0
+
+### Advanced Hooks
+**Exports**
+- useSyncExternalStore
+- useId
+- useDeferredValue
+
+Hooks for external store subscriptions, stable hydration-safe IDs, and deferred value propagation.
+
+#### useSyncExternalStore
+**Kind**
+hook
+
+**Summary**
+Subscribes to an external mutable store in a way that is safe for concurrent rendering.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useSyncExternalStore<Snapshot>(
+    subscribe: (onStoreChange: () => void) => () => void,
+    getSnapshot: () => Snapshot,
+    getServerSnapshot?: () => Snapshot
+): Snapshot;
+```
+
+**Guidance**
+- Use it for libraries or integration layers that bridge React to external mutable stores or browser APIs.
+- Ensure `subscribe` returns a cleanup function and `getSnapshot` returns a stable value unless the store actually changed.
+- Prefer higher-level application hooks on top of this primitive for app-facing ergonomics.
+
+**Example**
+Language: javascript
+
+```js
+import { useSyncExternalStore } from "react";
+
+function subscribe(callback) {
+  window.addEventListener("online", callback);
+  window.addEventListener("offline", callback);
+  return () => {
+    window.removeEventListener("online", callback);
+    window.removeEventListener("offline", callback);
+  };
+}
+
+function getSnapshot() {
+  return navigator.onLine;
+}
+
+export default function OnlineStatus() {
+  const isOnline = useSyncExternalStore(subscribe, getSnapshot);
+  return <span>{isOnline ? "Online" : "Offline"}</span>;
+}
+```
+
+**Since**
+18.0.0
+
+#### useId
+**Kind**
+hook
+
+**Summary**
+Generates a stable unique ID that stays consistent across server and client renders.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useId(): string;
+```
+
+**Guidance**
+- Use `useId` for relationships like `htmlFor`, `aria-labelledby`, and related accessibility attributes.
+- Derive related IDs by suffixing the base ID instead of calling `useId` repeatedly for the same logical cluster.
+- Do not use the generated value as a list key; keys should come from the data model.
+
+**Example**
+Language: javascript
+
+```js
+import { useId } from "react";
+
+function InputField({ label }) {
+  const id = useId();
+  return (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      <input id={id} type="text" />
+    </div>
+  );
+}
+```
+
+**Since**
+18.0.0
+
+#### useDeferredValue
+**Kind**
+hook
+
+**Summary**
+Defers propagation of a rapidly changing value so expensive work can lag behind urgent updates.
+
+**Definition**
+Language: typescript
+Source: npm:@types/react@18.3.0/index.d.ts
+
+```ts
+function useDeferredValue<T>(value: T): T;
+```
+
+**Guidance**
+- Use the immediate value for urgent UI feedback and the deferred value for expensive filtering, sorting, or rendering.
+- Combine `useDeferredValue` with memoized calculations to keep heavy derivations scoped to the lagged value.
+- Think of it as concurrency-aware deferral rather than time-based debouncing.
+
+**Example**
+Language: javascript
+
+```js
+import { useDeferredValue, useMemo, useState } from "react";
+
+function Search({ items }) {
+  const [text, setText] = useState("");
+  const deferredText = useDeferredValue(text);
+
+  const results = useMemo(() => {
+    return items.filter((item) => item.includes(deferredText));
+  }, [deferredText, items]);
+
+  return (
+    <>
+      <input value={text} onChange={(event) => setText(event.target.value)} />
+      <ResultsList results={results} />
+    </>
+  );
+}
+```
+
+**Since**
+18.0.0

--- a/website/static/distributions/claude/react/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/react/0.4.0/references/overview.md
@@ -1,0 +1,58 @@
+# React Overview
+
+## Snapshot
+
+- Spec name: react
+- Spec version: 0.4.0
+- Generated: 2026-03-12
+- Library version: ^18.3.0
+- Primary language: javascript
+- Homepage: https://react.dev
+- Source set: npm:@types/react@18.3.0/index.d.ts, react@18.3.1, legacy React API and Hooks references, selected react.dev reference pages for unchanged APIs
+
+**Tags**
+- react
+- frontend
+- hooks
+- library
+- typescript
+
+## Purpose
+
+This pack teaches an agent to use React's core public API for component
+composition, state, effects, concurrency, and performance-sensitive rendering
+tasks in a React 18.3-era codebase.
+
+## Guiding Principles
+
+- Prefer current function-component and hooks-based patterns over legacy class APIs.
+- Treat TypeScript signatures as the authoritative contract for each symbol.
+- Keep dependency arrays complete and use linting rules to enforce them.
+- Reach for `useMemo`, `useCallback`, and `memo` only when they stabilize real work.
+- Use concurrent features such as `useTransition`, `startTransition`, and `useDeferredValue` to keep urgent interactions responsive.
+- Use stable data IDs for list keys and avoid index keys unless the list is static.
+- Keep examples import-complete and aligned with modern ESM React usage.
+
+## Boundary Notes
+
+- Source material: `npm:@types/react@18.3.0/index.d.ts` as the primary contract source, `react@18.3.1` as the runtime reference, the React 18.3 upgrade note, the legacy React API and Hooks references, and selected current `react.dev` reference pages for unchanged APIs.
+- Organization follows the same mental-model grouping as the v0.3.0 pack: element creation, component helpers, core hooks, performance hooks, and advanced hooks.
+- Definitions are slightly compressed from the React 18.3 type surface to keep the primary contract readable without changing meaning.
+- Coverage was audited against `agents/react/0.3.0.md`, but prior pack content was not treated as the primary contract source.
+- `parse/react.out` remains a cross-check only because it appears to contain newer-era symbols that do not fit the locked `^18.3.0` target.
+
+## FAQ
+
+### Do I still need PureComponent or shouldComponentUpdate?
+For function-component codebases, prefer `memo` plus stable props and hook-based optimization patterns.
+
+### When should I choose useReducer over useState?
+Choose `useReducer` when state transitions are coupled, action-driven, or significantly more understandable as reducer logic than individual setter calls.
+
+## External Resources
+
+- React Documentation: https://react.dev
+- React API Reference (legacy): https://legacy.reactjs.org/docs/react-api.html
+- Hooks API Reference (legacy): https://legacy.reactjs.org/docs/hooks-reference.html
+- React 18.3 upgrade note: https://react.dev/blog/2024/04/25/react-19-upgrade-guide
+- TypeScript definitions (@types/react v18): https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/v18/index.d.ts

--- a/website/static/distributions/claude/react/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/react/0.4.0/references/troubleshooting.md
@@ -1,0 +1,22 @@
+# React Troubleshooting
+
+### Warning: Each child in a list should have a unique key prop.
+**Cause**
+The rendered array is missing a stable `key`, or it uses a value that changes between renders.
+
+**Fix**
+Use a deterministic key from the underlying data model and place it on the outermost element returned by the map.
+
+### Component re-renders even though it is wrapped in memo.
+**Cause**
+The parent passes new object, array, or callback references on each render.
+
+**Fix**
+Stabilize parent props with `useCallback` and `useMemo` when that stabilization prevents real re-render work.
+
+### Stale state or props appear inside a callback or effect.
+**Cause**
+The callback or effect closed over outdated values because the dependency list is incomplete or the state update relied on a captured value.
+
+**Fix**
+Use functional state updates when the next value depends on the previous one and keep dependency arrays complete.

--- a/website/static/distributions/claude/react/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/react/0.4.0/references/workflows.md
@@ -1,0 +1,14 @@
+# React Workflows
+
+### Controlled input with optimized filtering (React 18+)
+1. Use `useState` to keep the raw input value synchronized with the text field.
+2. Pass that value through `useDeferredValue` to create a lagged query for heavy rendering work.
+3. Use `useMemo` to derive the filtered list from the deferred value.
+4. Render the immediate value in the input and the deferred results in the expensive list UI.
+
+### Code-splitting a route or large component
+1. Identify the route or component whose bundle cost is worth deferring.
+2. Convert the target module to a default export if needed.
+3. Load it through `lazy(() => import("./MyComponent"))`.
+4. Wrap the render path in `Suspense`.
+5. Choose a fallback that fits the scope of the delayed work.

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: scaffold-eth-2
+description: Use for Scaffold-ETH 2 app setup, contract/frontend workflow, deployment, and debugging tasks. Helps with the local dev loop, generated bindings, and app structure decisions.
+---
+
+# Scaffold-ETH 2
+
+Use this skill when the task depends on Scaffold-ETH 2 project structure, the contract and frontend workflow, or the built-in developer surfaces.
+
+## Purpose
+
+This pack teaches an agent to use Scaffold-ETH 2 as a current, AI-ready dApp starter kit: run the normal three-terminal local loop, modify contracts and deploy scripts in the Hardhat workspace, rely on generated contract metadata instead of hand-editing addresses and ABIs, use the scaffold-specific frontend hooks and config surface rather than raw library snippets, and follow the repo’s built-in agent guidance and Context7 retrieval setup when working inside the repository.
+
+## When to use this skill
+
+- local three-terminal development workflow
+- deploy to frontend metadata and bindings flow
+- contract and frontend integration decisions
+- Scaffold-ETH-specific debugging and environment setup
+
+## Working style
+
+- Treat the current upstream `main` repo as a Hardhat-flavor Scaffold-ETH 2 workspace unless the cloned repo clearly contains `packages/foundry` instead.
+- Use the standard local loop: `yarn chain`, `yarn deploy`, and `yarn start` in separate terminals.
+- Do not edit `packages/nextjs/contracts/deployedContracts.ts` manually; it is generated from deployments.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/manifest.json
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "scaffold-eth-2",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/scaffold-eth-2/0.4.0.md",
+  "display_name": "Scaffold-ETH 2",
+  "description": "Use for Scaffold-ETH 2 app setup, contract/frontend workflow, deployment, and debugging tasks. Helps with the local dev loop, generated bindings, and app structure decisions.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/api-groups.md
@@ -1,0 +1,642 @@
+# Scaffold-ETH 2 API Groups
+
+### Workspace Entry Points
+**Exports**
+- yarn chain
+- yarn deploy
+- yarn start
+- yarn verify
+- yarn generate
+
+The root command surface for running the local chain, deploying contracts,
+starting the Next.js app, verifying contracts, and managing deployer accounts.
+
+#### yarn chain
+**Kind**
+workflow
+
+**Summary**
+Start the local Hardhat chain used for development and local deployment.
+
+**Definition**
+Language: json
+Source: root `package.json` and `packages/hardhat/package.json`
+
+```json
+{
+  "chain": "yarn hardhat:chain",
+  "hardhat:chain": "yarn workspace @se-2/hardhat chain",
+  "@se-2/hardhat#chain": "hardhat node --network hardhat --no-deploy"
+}
+```
+
+**Guidance**
+- Run this in its own terminal before local deploys and local frontend work.
+- This is the default local chain for the current checked-in Hardhat flavor.
+- Use `yarn fork` instead only when you intentionally want mainnet forking behavior.
+
+**Example**
+Language: bash
+Description: Start the local blockchain terminal.
+
+```bash
+yarn chain
+```
+
+#### yarn deploy
+**Kind**
+workflow
+
+**Summary**
+Deploy the contracts from the Hardhat workspace and regenerate frontend
+contract metadata.
+
+**Definition**
+Language: json
+Source: root `package.json`, `packages/hardhat/package.json`, and `packages/hardhat/hardhat.config.ts`
+
+```json
+{
+  "deploy": "yarn hardhat:deploy",
+  "hardhat:deploy": "yarn workspace @se-2/hardhat deploy",
+  "@se-2/hardhat#deploy": "ts-node scripts/runHardhatDeployWithPK.ts"
+}
+```
+
+**Guidance**
+- Treat this as both deployment and contract-metadata refresh because the Hardhat config extends the deploy task to run `generateTsAbis`.
+- Re-run it after contract ABI or address changes before expecting the frontend hooks and debug page to know about the new contract shape.
+- Use `--network <network>` when deploying off localhost.
+
+**Example**
+Language: bash
+Description: Deploy locally after the chain is running.
+
+```bash
+yarn deploy
+```
+
+#### yarn start
+**Kind**
+workflow
+
+**Summary**
+Start the Next.js frontend in development mode.
+
+**Definition**
+Language: json
+Source: root `package.json` and `packages/nextjs/package.json`
+
+```json
+{
+  "start": "yarn workspace @se-2/nextjs dev",
+  "@se-2/nextjs#dev": "next dev"
+}
+```
+
+**Guidance**
+- Run this after the local chain and deploy steps so the frontend can load contract metadata and local-network state correctly.
+- The current default app URL is `http://localhost:3000`.
+- Treat this as the frontend development server, not the production serve path.
+
+**Example**
+Language: bash
+Description: Start the frontend in the third terminal.
+
+```bash
+yarn start
+```
+
+#### yarn verify
+**Kind**
+workflow
+
+**Summary**
+Verify deployed contracts on a supported live network explorer.
+
+**Definition**
+Language: json
+Source: root `package.json` and `packages/hardhat/package.json`
+
+```json
+{
+  "verify": "yarn hardhat:verify",
+  "@se-2/hardhat#verify": "hardhat etherscan-verify"
+}
+```
+
+**Guidance**
+- Use this after a live-network deployment, not for localhost development.
+- The checked-in Hardhat config uses `ETHERSCAN_V2_API_KEY` with explorer defaults as a fallback.
+- Keep the target network explicit when verifying.
+
+**Example**
+Language: bash
+Description: Verify contracts on Sepolia.
+
+```bash
+yarn verify --network sepolia
+```
+
+#### yarn generate
+**Kind**
+workflow
+
+**Summary**
+Generate a deployer account for the current workspace.
+
+**Definition**
+Language: json
+Source: root `package.json` and `packages/hardhat/package.json`
+
+```json
+{
+  "generate": "yarn account:generate",
+  "account:generate": "yarn workspace @se-2/hardhat account:generate",
+  "@se-2/hardhat#account:generate": "hardhat run scripts/generateAccount.ts"
+}
+```
+
+**Guidance**
+- Use this when you need a dedicated deployer instead of the default local Hardhat account.
+- Pair it with `yarn account` or `yarn account:import` as needed.
+- For live networks, make sure the resulting deployer actually has gas funds.
+
+**Example**
+Language: bash
+Description: Generate a new deployer account.
+
+```bash
+yarn generate
+```
+
+### Hardhat Deployment and Generated Metadata
+**Exports**
+- deploy task extension
+- packages/hardhat/deploy/00_deploy_your_contract.ts
+- packages/nextjs/contracts/deployedContracts.ts
+
+The contract-side source of truth and the metadata bridge that the frontend
+depends on after deploy.
+
+#### deploy task extension
+**Kind**
+workflow
+
+**Summary**
+The Hardhat config extends the standard deploy task so ABI/address metadata is
+regenerated for the frontend immediately after deploy.
+
+**Definition**
+Language: typescript
+Source: `packages/hardhat/hardhat.config.ts`
+
+```ts
+task("deploy").setAction(async (args, hre, runSuper) => {
+  await runSuper(args);
+  await generateTsAbis(hre);
+});
+```
+
+**Guidance**
+- This is the key reason the frontend can track contract changes automatically after deploy.
+- Do not remove or bypass this behavior unless you replace the metadata generation flow deliberately.
+- When contract info looks stale in the frontend, start by checking whether deploy completed and the generation step ran.
+
+**Example**
+Language: text
+Description: Understand why `yarn deploy` also updates the frontend contract metadata.
+
+```text
+Scaffold-ETH 2 extends the Hardhat deploy task so ABI/address generation runs automatically after deploy.
+```
+
+#### packages/hardhat/deploy/00_deploy_your_contract.ts
+**Kind**
+workflow
+
+**Summary**
+Starter deploy script showing the expected Hardhat deploy pattern, deployer
+account usage, constructor args, and tagged deployment.
+
+**Definition**
+Language: typescript
+Source: `packages/hardhat/deploy/00_deploy_your_contract.ts`
+
+```ts
+const deployYourContract: DeployFunction = async function (hre) {
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy } = hre.deployments;
+
+  await deploy("YourContract", {
+    from: deployer,
+    args: [deployer],
+    log: true,
+    autoMine: true,
+  });
+};
+
+deployYourContract.tags = ["YourContract"];
+```
+
+**Guidance**
+- Use this as the pattern for new contract deploy files in the Hardhat flavor.
+- Replace `YourContract` and constructor args with your real deployment logic instead of trying to preserve the starter example unchanged.
+- Use deployment tags when you want targeted deploy runs.
+
+**Example**
+Language: bash
+Description: Deploy only one tagged contract script.
+
+```bash
+yarn deploy --tags YourContract
+```
+
+#### packages/nextjs/contracts/deployedContracts.ts
+**Kind**
+config
+
+**Summary**
+Autogenerated frontend contract registry populated from deployment output.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/contracts/deployedContracts.ts`
+
+```ts
+/**
+ * This file is autogenerated by Scaffold-ETH.
+ * You should not edit it manually or your changes might be overwritten.
+ */
+const deployedContracts = {} as const;
+```
+
+**Guidance**
+- Treat this as generated output only.
+- The frontend hooks and debug UI depend on this file being current.
+- If contract info is missing, regenerate it by deploying again instead of editing this file by hand.
+
+**Example**
+Language: text
+Description: Expected maintenance rule for contract metadata.
+
+```text
+Do not edit deployedContracts.ts manually; update contracts and run yarn deploy.
+```
+
+### Frontend Contract and Network Surface
+**Exports**
+- packages/nextjs/scaffold.config.ts
+- packages/nextjs/services/web3/wagmiConfig.tsx
+- useScaffoldReadContract
+- useScaffoldWriteContract
+- /debug
+
+The frontend-specific configuration and hook surface for reading/writing
+contracts and debugging deployed metadata.
+
+#### packages/nextjs/scaffold.config.ts
+**Kind**
+config
+
+**Summary**
+Main Scaffold-ETH frontend config for target networks, polling, RPC overrides,
+WalletConnect, and burner wallet behavior.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/scaffold.config.ts`
+
+```ts
+type ScaffoldConfig = {
+  targetNetworks: readonly Chain[];
+  pollingInterval: number;
+  alchemyApiKey: string;
+  rpcOverrides?: Record<number, string>;
+  walletConnectProjectId: string;
+  burnerWalletMode: "localNetworksOnly" | "allNetworks" | "disabled";
+};
+```
+
+**Guidance**
+- Change `targetNetworks` first when moving the app off the default local Hardhat network.
+- Keep RPC overrides and API keys here instead of scattering network config through components.
+- Adjust the polling interval intentionally for live networks and especially L2 targets.
+
+**Example**
+Language: typescript
+Description: Switch the app target network from local Hardhat to Sepolia.
+
+```ts
+import * as chains from "viem/chains";
+
+const scaffoldConfig = {
+  targetNetworks: [chains.sepolia],
+  pollingInterval: 3000,
+  // ...
+} as const;
+```
+
+#### packages/nextjs/services/web3/wagmiConfig.tsx
+**Kind**
+config
+
+**Summary**
+The wagmi client configuration that derives enabled chains from
+`scaffold.config.ts`, forces mainnet availability for shared utilities such as
+ENS, and builds fallback transports.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/services/web3/wagmiConfig.tsx`
+
+```ts
+export const wagmiConfig = createConfig({
+  chains: enabledChains,
+  connectors: wagmiConnectors(),
+  ssr: true,
+  client({ chain }) {
+    return createClient({
+      chain,
+      transport: fallback(rpcFallbacks),
+      ...(chain.id !== hardhat.id ? { pollingInterval: scaffoldConfig.pollingInterval } : {}),
+    });
+  },
+});
+```
+
+**Guidance**
+- Treat this as the transport layer derived from `scaffold.config.ts`, not the first place to hardcode app networks.
+- The config always ensures mainnet is available once for things like ENS resolution and ETH price lookups.
+- Put network intent in `scaffold.config.ts`; use this file to understand transport fallback behavior and SSR usage.
+
+**Example**
+Language: text
+Description: Where to look when RPC fallback behavior is not what you expect.
+
+```text
+Adjust target networks and overrides in scaffold.config.ts, then inspect wagmiConfig.tsx for how fallback transports are built.
+```
+
+#### useScaffoldReadContract
+**Kind**
+hook
+
+**Summary**
+Wrapper around wagmi contract reads that auto-loads ABI and address info from
+generated contract metadata for the selected network.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/hooks/scaffold-eth/useScaffoldReadContract.ts`
+
+```ts
+export const useScaffoldReadContract = <
+  TContractName extends ContractName,
+  TFunctionName extends ExtractAbiFunctionNames<ContractAbi<TContractName>, "pure" | "view">
+>(
+  config: UseScaffoldReadConfig<TContractName, TFunctionName>
+) => { /* wagmi read wrapper */ };
+```
+
+**Guidance**
+- Prefer this over ad hoc `useReadContract` calls when you are reading deployed contracts inside the Scaffold-ETH frontend.
+- It resolves ABI and address from `deployedContracts.ts` and `externalContracts.ts`.
+- Watch mode is enabled by default through block tracking, so be intentional when disabling or overriding it.
+- Use the current hook name exactly; `AGENTS.md` explicitly warns against stale old names like `useScaffoldContractRead`.
+
+**Example**
+Language: typescript
+Description: Read a view function from the deployed contract.
+
+```ts
+const { data: totalCounter } = useScaffoldReadContract({
+  contractName: "YourContract",
+  functionName: "userGreetingCounter",
+  args: ["0xd8da6bf26964af9d7eed9e03e53415d37aa96045"],
+});
+```
+
+#### useScaffoldWriteContract
+**Kind**
+hook
+
+**Summary**
+Wrapper around wagmi contract writes that resolves deployed contract metadata,
+checks wallet/network state, optionally simulates the write, and sends the
+transaction through the scaffold transactor flow.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts`
+
+```ts
+export function useScaffoldWriteContract<TContractName extends ContractName>(
+  config: UseScaffoldWriteConfig<TContractName>
+): ScaffoldWriteContractReturnType<TContractName>;
+```
+
+**Guidance**
+- Prefer this over raw `useWriteContract` for normal Scaffold-ETH contract writes.
+- It already handles missing deployment metadata, wallet connection checks, wrong-network errors, and optional simulation.
+- Use the object-parameter form; the string-parameter overload is deprecated in the source.
+- Use the current hook name exactly; `AGENTS.md` explicitly warns against stale old names like `useScaffoldContractWrite`.
+
+**Example**
+Language: typescript
+Description: Write to a payable contract function.
+
+```ts
+const { writeContractAsync, isPending } = useScaffoldWriteContract({
+  contractName: "YourContract",
+});
+
+await writeContractAsync({
+  functionName: "setGreeting",
+  args: ["gm"],
+  value: parseEther("0.01"),
+});
+```
+
+#### /debug
+**Kind**
+workflow
+
+**Summary**
+The built-in Debug Contracts page for interacting with deployed contracts from
+the generated metadata surface.
+
+**Definition**
+Language: typescript
+Source: `packages/nextjs/app/debug/page.tsx`
+
+```tsx
+const Debug: NextPage = () => {
+  return (
+    <>
+      <DebugContracts />
+      <div>Debug Contracts</div>
+    </>
+  );
+};
+```
+
+**Guidance**
+- Use this as the first frontend inspection surface after deploying locally.
+- If it looks empty or broken, check whether deploy metadata was regenerated before debugging the page itself.
+- Treat it as scaffolded operator UI, not as the final product UX for your app.
+
+**Example**
+Language: text
+Description: Built-in route for contract interaction after local deploy.
+
+```text
+Open http://localhost:3000/debug after yarn chain + yarn deploy + yarn start.
+```
+
+### AI Agent Surface
+**Exports**
+- AGENTS.md
+- .mcp.json
+- .agents/skills/*
+- editor agent directories
+
+The repo’s built-in instructions for coding agents, retrieval setup, and
+specialized local skill routing.
+
+#### AGENTS.md
+**Kind**
+workflow
+
+**Summary**
+Primary agent instruction file describing flavor detection, common commands,
+contract interaction hooks, styling expectations, and retrieval-first behavior.
+
+**Definition**
+Language: markdown
+Source: `AGENTS.md`
+
+```md
+Check which package exists:
+- packages/hardhat => Hardhat flavor
+- packages/foundry => Foundry flavor
+
+Use hooks from packages/nextjs/hooks/scaffold-eth
+Use Context7 MCP for up-to-date library docs
+```
+
+**Guidance**
+- Read this first before modifying Scaffold-ETH 2 with an AI agent.
+- It contains current hook-name corrections, flavor detection, and style conventions that are more specific than generic Hardhat/Next/Wagmi knowledge.
+- Treat it as the authoritative agent workflow surface for this repo.
+
+**Example**
+Language: text
+Description: First retrieval step for an AI agent inside the repo.
+
+```text
+Open AGENTS.md first, detect the repo flavor, then follow the repo-specific hook and styling rules.
+```
+
+#### .mcp.json
+**Kind**
+config
+
+**Summary**
+Repo-scoped MCP configuration that points agents to the Context7 documentation
+server.
+
+**Definition**
+Language: json
+Source: `.mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+**Guidance**
+- Use this when you need current library docs for Wagmi, Viem, RainbowKit, DaisyUI, Next.js, Hardhat, and related stack pieces.
+- Treat it as a retrieval aid, not a replacement for the repo’s own guidance.
+- If a coding agent supports repo-local MCP config, this file is part of the expected setup.
+
+**Example**
+Language: text
+Description: Retrieve current library docs while working in the repo.
+
+```text
+Use the configured Context7 MCP server to fetch up-to-date docs for Wagmi, Viem, Hardhat, or Next.js.
+```
+
+#### .agents/skills/*
+**Kind**
+workflow
+
+**Summary**
+Local skill catalog for specialized Ethereum topics such as ERC-20, ERC-721,
+SIWE, EIP-712, EIP-5792, Ponder, and Solidity security.
+
+**Definition**
+Language: text
+Source: `.agents/skills/*`
+
+```text
+.agents/skills/erc-20/SKILL.md
+.agents/skills/erc-721/SKILL.md
+.agents/skills/eip-712/SKILL.md
+.agents/skills/eip-5792/SKILL.md
+.agents/skills/ponder/SKILL.md
+.agents/skills/siwe/SKILL.md
+.agents/skills/solidity-security/SKILL.md
+```
+
+**Guidance**
+- Fetch the matching skill before implementing a topic-specific feature instead of relying only on generic Ethereum memory.
+- Use these for narrow protocol or standards work; use `AGENTS.md` first for the repo-wide workflow.
+- Keep the retrieval narrow and task-specific rather than loading all skills at once.
+
+**Example**
+Language: text
+Description: Use a local skill for Sign-In with Ethereum work.
+
+```text
+Read .agents/skills/siwe/SKILL.md before implementing wallet-auth or SIWE session flows.
+```
+
+#### editor agent directories
+**Kind**
+config
+
+**Summary**
+Parallel agent-instruction surfaces for supported coding environments such as
+Claude, Cursor, and OpenCode.
+
+**Definition**
+Language: text
+Source: `.claude`, `.cursor`, `.opencode`, and `.agents/agents`
+
+```text
+.claude/
+.cursor/
+.opencode/
+.agents/agents/grumpy-carlos-code-reviewer.md
+```
+
+**Guidance**
+- Treat these as environment-specific instruction mirrors or extensions around the repo’s shared agent guidance.
+- The `grumpy-carlos-code-reviewer` agent is a repo-specific post-change review persona, not a general Ethereum coding tool.
+- If you are building agent workflows around Scaffold-ETH 2, these directories are part of the intended surface.
+
+**Example**
+Language: text
+Description: Inspect repo-specific agent support beyond AGENTS.md.
+
+```text
+Check .claude, .cursor, .opencode, and .agents/agents when configuring editor- or CLI-specific agent behavior.
+```

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/overview.md
@@ -1,0 +1,77 @@
+# Scaffold-ETH 2 Overview
+
+## Snapshot
+
+- Spec name: scaffold-eth-2
+- Spec version: 0.4.0
+- Generated: 2026-03-16
+- Library version: scaffold-eth-2 current-docs + @se-2/hardhat^0.0.1 + @se-2/nextjs^0.1.0
+- Primary language: typescript
+- Homepage: https://github.com/scaffold-eth/scaffold-eth-2
+- Source set: upstream `main` at `d0432d167a376289c975b6ddb282e63c203d93c3`; `README.md`; `AGENTS.md`; `.mcp.json`; `CONTRIBUTING.md`; root `package.json`; `packages/hardhat/package.json`; `packages/hardhat/hardhat.config.ts`; `packages/hardhat/deploy/00_deploy_your_contract.ts`; `packages/hardhat/contracts/YourContract.sol`; `packages/nextjs/package.json`; `packages/nextjs/scaffold.config.ts`; `packages/nextjs/services/web3/wagmiConfig.tsx`; `packages/nextjs/contracts/deployedContracts.ts`; `packages/nextjs/hooks/scaffold-eth/useScaffoldReadContract.ts`; `packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts`; `packages/nextjs/app/debug/page.tsx`; and `parse/scaffold-eth-2-docs-v0.4.0.md`
+
+**Tags**
+- scaffold-eth
+- ethereum
+- hardhat
+- nextjs
+- wagmi
+- viem
+- ai-agents
+
+## Purpose
+
+This pack teaches an agent to use Scaffold-ETH 2 as a current, AI-ready dApp
+starter kit: run the normal three-terminal local loop, modify contracts and
+deploy scripts in the Hardhat workspace, rely on generated contract metadata
+instead of hand-editing addresses and ABIs, use the scaffold-specific frontend
+hooks and config surface rather than raw library snippets, and follow the
+repo’s built-in agent guidance and Context7 retrieval setup when working inside
+the repository.
+
+## Guiding Principles
+
+- Treat the current upstream `main` repo as a Hardhat-flavor Scaffold-ETH 2 workspace unless the cloned repo clearly contains `packages/foundry` instead.
+- Use the standard local loop: `yarn chain`, `yarn deploy`, and `yarn start` in separate terminals.
+- Do not edit `packages/nextjs/contracts/deployedContracts.ts` manually; it is generated from deployments.
+- Prefer `useScaffoldReadContract` and `useScaffoldWriteContract` over old or raw contract hook patterns when working inside the frontend.
+- Keep network configuration in `packages/nextjs/scaffold.config.ts` and transport behavior in `packages/nextjs/services/web3/wagmiConfig.tsx`.
+- Treat `packages/hardhat/deploy/00_deploy_your_contract.ts` and `packages/hardhat/contracts/YourContract.sol` as starter examples meant to be replaced, not permanent app design.
+- Prefer DaisyUI and `@scaffold-ui/components` patterns instead of raw one-off Tailwind utility implementations when the repo already has a scaffolded component path.
+- Follow the repo’s own AI guidance first: `AGENTS.md`, `.agents/skills/*`, and the configured Context7 MCP server.
+- Remember that the debug surface at `/debug` assumes deployments and generated metadata already exist.
+- Use Node `>=20.18.3` and the repo’s Yarn workspace flow; do not silently downgrade the toolchain assumptions.
+
+## Boundary Notes
+
+- The root README frames Scaffold-ETH 2 as an up-to-date dApp toolkit built from Next.js, RainbowKit, Wagmi, Viem, Hardhat or Foundry, and TypeScript.
+- The checked-in `main` repo currently contains `packages/hardhat` and `packages/nextjs`; `AGENTS.md` still documents the broader two-flavor model, so flavor detection is a first-class boundary.
+- The Hardhat deploy task is extended to run `generateTsAbis` after deploy, which keeps the frontend contract metadata aligned with the latest deployment output.
+- The frontend intentionally wraps wagmi and local config in scaffold-specific hooks and utilities. The current guidance explicitly says to use `useScaffoldReadContract` and `useScaffoldWriteContract`, not stale old hook names.
+- The repository ships first-party agent guidance in `AGENTS.md`, `.agents/skills/*`, `.claude`, `.cursor`, and `.mcp.json`; that is part of the product surface because it changes how coding agents should work inside the repo.
+- `CONTRIBUTING.md` shows that upstream still expects human-reviewed fork-and-pull GitHub workflows even though the repo is AI-ready.
+
+## FAQ
+
+### Is Scaffold-ETH 2 Hardhat or Foundry?
+- The broader product supports both flavors.
+- The current upstream `main` repo inspected here is Hardhat-flavored because it contains `packages/hardhat`.
+
+### Should I edit `deployedContracts.ts` manually?
+- No.
+- It is generated output and is meant to be refreshed through `yarn deploy`.
+
+### Should I use raw wagmi hooks directly?
+- Not by default inside this repo.
+- Scaffold-ETH 2 already wraps the common contract interaction flows in scaffold-specific hooks that load addresses and ABIs for you.
+
+### Is Scaffold-ETH 2 already AI-ready?
+- Yes.
+- The current repo ships `AGENTS.md`, local skills in `.agents/skills/*`, editor-specific agent directories, and a configured Context7 MCP entry.
+
+## External Resources
+
+- Scaffold-ETH 2 docs: https://docs.scaffoldeth.io
+- Scaffold-ETH 2 website: https://scaffoldeth.io
+- Scaffold-ETH 2 repository: https://github.com/scaffold-eth/scaffold-eth-2
+- Quickstart installer: https://www.npmjs.com/package/create-eth

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/troubleshooting.md
@@ -1,0 +1,47 @@
+# Scaffold-ETH 2 Troubleshooting
+
+### The frontend says the contract is not deployed
+**Cause**
+- `useScaffoldWriteContract` and related helpers read from generated deployment metadata.
+- The deploy step may not have run, or it ran before your latest contract/deploy changes.
+
+**Fix**
+- Run `yarn deploy` again.
+- Verify that the deployed contract metadata was regenerated before debugging the UI layer.
+
+### `deployedContracts.ts` is empty, stale, or keeps being overwritten
+**Cause**
+- The file is generated output.
+- Manual edits are overwritten because the deploy flow regenerates it from deployment artifacts.
+
+**Fix**
+- Stop editing `packages/nextjs/contracts/deployedContracts.ts` directly.
+- Change the contract or deploy script, then run `yarn deploy` to regenerate the metadata correctly.
+
+### The wallet is connected, but writes still fail
+**Cause**
+- The wallet is connected to the wrong network for the selected target network.
+- `useScaffoldWriteContract` explicitly guards against wrong-network writes.
+
+**Fix**
+- Switch the wallet to the selected target network.
+- Check `packages/nextjs/scaffold.config.ts` if the app is targeting a different chain than you expected.
+
+### The docs mention Foundry, but this repo only has Hardhat
+**Cause**
+- `AGENTS.md` documents the broader two-flavor Scaffold-ETH 2 model.
+- The current upstream `main` workspace you cloned contains `packages/hardhat`, not `packages/foundry`.
+
+**Fix**
+- Follow Hardhat-flavor instructions for this repo.
+- Only apply Foundry guidance when the cloned workspace actually includes `packages/foundry`.
+
+### The AI agent keeps reaching for generic wagmi or old Scaffold-ETH examples
+**Cause**
+- The repo has its own current contract hooks, naming conventions, and agent guidance.
+- Older blog posts or memory may use deprecated hook names.
+
+**Fix**
+- Re-read `AGENTS.md`.
+- Use `useScaffoldReadContract` and `useScaffoldWriteContract` exactly as currently named in the repo.
+- Pull current library docs through Context7 only after grounding on the repo’s own guidance.

--- a/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/scaffold-eth-2/0.4.0/references/workflows.md
@@ -1,0 +1,31 @@
+# Scaffold-ETH 2 Workflows
+
+### Start the local Scaffold-ETH 2 loop
+1. Run `yarn chain` in the first terminal.
+2. Run `yarn deploy` in the second terminal to deploy contracts and regenerate frontend metadata.
+3. Run `yarn start` in the third terminal to boot the Next.js app on `http://localhost:3000`.
+4. Open `/debug` to confirm the deployed contract surface is visible.
+
+### Add or modify a contract
+1. Edit or replace `packages/hardhat/contracts/YourContract.sol` and its matching deploy script in `packages/hardhat/deploy/`.
+2. Re-run `yarn deploy` so the deployment and generated contract metadata stay aligned.
+3. Confirm `packages/nextjs/contracts/deployedContracts.ts` reflects the new deploy output instead of editing it manually.
+4. Update frontend interactions only after the generated metadata is current.
+
+### Build frontend contract interactions the scaffold way
+1. Set the right target networks in `packages/nextjs/scaffold.config.ts`.
+2. Use `useScaffoldReadContract` for view/pure calls and `useScaffoldWriteContract` for writes.
+3. Keep UI components aligned with DaisyUI and `@scaffold-ui/components` patterns.
+4. Use the `/debug` page to sanity-check ABI/address integration before building product-specific UI.
+
+### Deploy to a live network
+1. Configure the deployer account and relevant API keys or RPC settings.
+2. Run `yarn deploy --network <network>`.
+3. Run `yarn verify --network <network>` after deployment.
+4. Update frontend target networks and RPC/API config for the live environment in `packages/nextjs/scaffold.config.ts`.
+
+### Work effectively as an AI agent inside the repo
+1. Read `AGENTS.md` first and detect whether the repo is Hardhat or Foundry flavored.
+2. Use Context7 through `.mcp.json` for current third-party library docs.
+3. Pull in only the relevant `.agents/skills/*` topic skill for the task at hand.
+4. Follow repo-specific hook names, component choices, and contract-metadata rules instead of generic stack assumptions.

--- a/website/static/distributions/claude/supabase-js/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/supabase-js/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: supabase-js
+description: Use for Supabase client setup, auth, database, storage, realtime, and Edge Function tasks. Helps with API usage, runtime boundaries, and debugging.
+---
+
+# Supabase JS
+
+Use this skill when the task depends on Supabase client behavior across auth, database, storage, realtime, or Edge Function surfaces.
+
+## Purpose
+
+This pack teaches an agent to use `@supabase/supabase-js` as the isomorphic JavaScript client for Supabase services: initialize the client correctly for the target runtime, use auth/session APIs with the right trust model, query PostgREST tables and RPC functions, manage storage buckets and files, subscribe to Realtime channels, and invoke deployed Edge Functions without confusing client SDK usage with dashboard configuration or server-side authoring workflows.
+
+## When to use this skill
+
+- client initialization and runtime setup
+- auth, session, and permission boundaries
+- database, storage, and realtime operations
+- Edge Function invocation and debugging
+
+## Working style
+
+- Treat `createClient(...)` as the entrypoint; the returned client composes auth, database, storage, functions, and realtime.
+- Prefer the stable published npm surface over upstream `master` drift when they diverge.
+- Keep auth, database, storage, realtime, and functions mentally separate even though they share one client.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/supabase-js/0.4.0/manifest.json
+++ b/website/static/distributions/claude/supabase-js/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "supabase-js",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/supabase-js/0.4.0.md",
+  "display_name": "Supabase JS",
+  "description": "Use for Supabase client setup, auth, database, storage, realtime, and Edge Function tasks. Helps with API usage, runtime boundaries, and debugging.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/supabase-js/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/supabase-js/0.4.0/references/api-groups.md
@@ -1,0 +1,979 @@
+# Supabase JS API Groups
+
+### Client Initialization and Shared Types
+**Exports**
+- createClient
+- SupabaseClientOptions
+- QueryData
+- QueryResult
+- QueryError
+
+The entrypoint for configuring one Supabase client and the helper types most
+useful in TypeScript-heavy codebases.
+
+#### createClient
+**Kind**
+function
+
+**Summary**
+Create a new Supabase client bound to one project URL, one publishable/anon key,
+and optional auth, database, runtime, and header settings.
+
+**Definition**
+Language: typescript
+Source: `src/index.ts` and `dist/index.d.mts`
+
+```ts
+createClient(
+  supabaseUrl: string,
+  supabaseKey: string,
+  options?: SupabaseClientOptions<SchemaName>
+): SupabaseClient<Database, SchemaNameOrClientOptions, SchemaName>;
+```
+
+**Guidance**
+- Use one shared client per runtime context unless you intentionally need different schemas, headers, or auth behavior.
+- Pass a publishable or anon key in ordinary app code; do not treat browser clients as a place for service-role secrets.
+- Use `global.fetch` when the runtime's fetch implementation is the compatibility boundary, especially in Workers-like environments.
+- If you set `accessToken`, you are opting into third-party token supply and giving up the built-in `supabase.auth` namespace on that client.
+- Treat custom schemas, React Native storage, and custom headers as targeted configuration choices, not default boilerplate.
+
+**Example**
+Language: typescript
+Description: Create a browser or server client with custom headers and fetch.
+
+```ts
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+  {
+    global: {
+      headers: { 'x-application-name': 'agent-hub-demo' },
+      fetch: fetch.bind(globalThis),
+    },
+  }
+);
+```
+
+#### SupabaseClientOptions
+**Kind**
+type
+
+**Summary**
+Configuration surface for database schema selection, auth persistence, realtime,
+storage, custom fetch, headers, and third-party access token integration.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+type SupabaseClientOptions<SchemaName> = {
+  db?: {
+    schema?: SchemaName;
+    timeout?: number;
+    urlLengthLimit?: number;
+  };
+  auth?: {
+    autoRefreshToken?: boolean;
+    storageKey?: string;
+    persistSession?: boolean;
+    detectSessionInUrl?: boolean | ((url: URL, params: Record<string, string>) => boolean);
+    storage?: SupabaseAuthClientOptions['storage'];
+    userStorage?: SupabaseAuthClientOptions['userStorage'];
+    flowType?: SupabaseAuthClientOptions['flowType'];
+    debug?: SupabaseAuthClientOptions['debug'];
+    lock?: SupabaseAuthClientOptions['lock'];
+    throwOnError?: SupabaseAuthClientOptions['throwOnError'];
+  };
+  realtime?: RealtimeClientOptions;
+  storage?: StorageClientOptions;
+  global?: {
+    fetch?: typeof fetch;
+    headers?: Record<string, string>;
+  };
+  accessToken?: () => Promise<string | null>;
+};
+```
+
+**Guidance**
+- Start with only the options you actually need; do not cargo-cult full option objects into every client.
+- Use `db.schema` to set the default PostgREST schema for this client.
+- In React Native, explicitly provide auth storage and usually disable `detectSessionInUrl`.
+- Use `accessToken` only when Supabase auth is not your session source.
+- Prefer `throwOnError` as an intentional auth-layer policy choice rather than a blanket default.
+
+**Example**
+Language: typescript
+Description: Configure a React Native client with persistent auth storage.
+
+```ts
+import 'react-native-url-polyfill/auto';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(url, key, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});
+```
+
+#### QueryData
+**Kind**
+type
+
+**Summary**
+Infer the non-null `data` shape from a Supabase query promise.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+type QueryData<T> = T extends PromiseLike<{ data: infer U }> ? Exclude<U, null> : never;
+```
+
+**Guidance**
+- Use this when you want inferred query result types without manually duplicating row shapes.
+- It is especially useful after composing a query builder with joins or nested selects.
+- Keep the originating query expression close to the type alias so the inference remains understandable.
+
+**Example**
+Language: typescript
+Description: Infer the row shape from a query builder.
+
+```ts
+const profilesQuery = supabase.from('profiles').select('id, username');
+
+type Profiles = QueryData<typeof profilesQuery>;
+```
+
+#### QueryResult
+**Kind**
+type
+
+**Summary**
+Infer the full resolved response type from a Supabase query promise.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+type QueryResult<T> = T extends PromiseLike<infer U> ? U : never;
+```
+
+**Guidance**
+- Use this when you need the complete response contract rather than only the `data` field.
+- It is useful for helpers that wrap queries and forward the whole Supabase response.
+
+**Example**
+Language: typescript
+Description: Infer the full response type from a query builder.
+
+```ts
+const profilesQuery = supabase.from('profiles').select('id, username');
+
+type ProfilesResponse = QueryResult<typeof profilesQuery>;
+```
+
+#### QueryError
+**Kind**
+type
+
+**Summary**
+The PostgREST error type re-exported by `@supabase/supabase-js` for query-layer
+failures.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+type QueryError = PostgrestError;
+```
+
+**Guidance**
+- Use this when typing utilities that handle query failures from `from(...)` or `rpc(...)`.
+- Do not treat it as the universal error type for auth, storage, or functions; those surfaces use different error contracts.
+
+**Example**
+Language: typescript
+Description: Type a helper that formats PostgREST errors.
+
+```ts
+function formatQueryError(error: QueryError | null) {
+  return error?.message ?? null;
+}
+```
+
+### Auth and Session Management
+**Exports**
+- supabase.auth
+- supabase.auth.signInWithPassword
+- supabase.auth.getSession
+- supabase.auth.getUser
+- supabase.auth.signOut
+- supabase.auth.onAuthStateChange
+
+Built-in auth/session APIs when the client is using Supabase Auth rather than a
+custom `accessToken` callback.
+
+#### supabase.auth
+**Kind**
+object
+
+**Summary**
+The built-in Supabase Auth client for sign-in, session, user, and auth-state
+operations.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+auth: SupabaseAuthClient;
+```
+
+**Guidance**
+- This namespace is available only when the client was not configured with the `accessToken` option.
+- Use it for session lifecycle, provider login, OTP flows, and auth event subscriptions.
+- If you need both Supabase Auth and a separate token-provider client, create two clients instead of trying to mix models on one client.
+
+**Example**
+Language: typescript
+Description: Read the current session with the built-in auth client.
+
+```ts
+const { data, error } = await supabase.auth.getSession();
+```
+
+#### supabase.auth.signInWithPassword
+**Kind**
+function
+
+**Summary**
+Sign in an existing user with email+password or phone+password.
+
+**Definition**
+Language: typescript
+Source: `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`
+
+```ts
+signInWithPassword(
+  credentials: SignInWithPasswordCredentials
+): Promise<AuthTokenResponsePassword>;
+```
+
+**Guidance**
+- Use this for direct password login flows when email/password or phone/password is the intended auth UX.
+- Do not rely on the error details to distinguish “user missing” from “wrong password” or “social login only”; the SDK explicitly warns against that assumption.
+- Keep this on the client where user-entered credentials belong; do not proxy it through ad hoc server handlers unless you have a clear reason.
+
+**Example**
+Language: typescript
+Description: Sign in with email and password.
+
+```ts
+const { data, error } = await supabase.auth.signInWithPassword({
+  email: 'ada@example.com',
+  password: 'correct horse battery staple',
+});
+```
+
+#### supabase.auth.getSession
+**Kind**
+function
+
+**Summary**
+Return the current session, refreshing it if necessary, using the client’s
+attached storage.
+
+**Definition**
+Language: typescript
+Source: `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`
+
+```ts
+getSession(): Promise<{
+  data: { session: Session | null };
+  error: AuthError | null;
+}>;
+```
+
+**Guidance**
+- Use this for ordinary client-side session access.
+- Be careful on server-like environments where storage is cookie-backed or request-scoped; the docs explicitly warn that the returned session may not be authentic enough for authorization decisions.
+- If you need verified identity for trusted server logic, use `getUser()` instead.
+
+**Example**
+Language: typescript
+Description: Read the current access token from the session.
+
+```ts
+const { data } = await supabase.auth.getSession();
+const accessToken = data.session?.access_token ?? null;
+```
+
+#### supabase.auth.getUser
+**Kind**
+function
+
+**Summary**
+Fetch the current authenticated user from the Supabase Auth server.
+
+**Definition**
+Language: typescript
+Source: `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`
+
+```ts
+getUser(jwt?: string): Promise<UserResponse>;
+```
+
+**Guidance**
+- Use this when authenticity matters more than avoiding a network call.
+- This is the safer choice for server-side authorization logic because it validates against the Auth server rather than trusting local storage.
+- If you already have a specific JWT to validate, pass it explicitly.
+
+**Example**
+Language: typescript
+Description: Fetch the authenticated user for trusted server logic.
+
+```ts
+const { data, error } = await supabase.auth.getUser();
+const user = data.user;
+```
+
+#### supabase.auth.signOut
+**Kind**
+function
+
+**Summary**
+Sign out the current user and clear local session state.
+
+**Definition**
+Language: typescript
+Source: `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`
+
+```ts
+signOut(options?: SignOut): Promise<{ error: AuthError | null }>;
+```
+
+**Guidance**
+- Use this for ordinary client sign-out flows.
+- Inside browser contexts it clears local session state and emits `"SIGNED_OUT"` for the normal scope.
+- Do not assume this revokes existing access tokens immediately; the docs explicitly call out refresh-token revocation boundaries.
+
+**Example**
+Language: typescript
+Description: Sign the current user out.
+
+```ts
+const { error } = await supabase.auth.signOut();
+```
+
+#### supabase.auth.onAuthStateChange
+**Kind**
+function
+
+**Summary**
+Subscribe to auth-state change events such as sign-in, sign-out, and token
+refresh.
+
+**Definition**
+Language: typescript
+Source: `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`
+
+```ts
+onAuthStateChange(
+  callback: (event: AuthChangeEvent, session: Session | null) => void
+): {
+  data: { subscription: Subscription };
+};
+```
+
+**Guidance**
+- Use this to react to session changes in long-lived client runtimes.
+- Prefer a synchronous callback; the auth package explicitly warns that async callbacks can deadlock because they run under an exclusive lock.
+- Keep cleanup logic by unsubscribing when your framework/component lifecycle ends.
+
+**Example**
+Language: typescript
+Description: Track auth-state changes without using an async callback.
+
+```ts
+const {
+  data: { subscription },
+} = supabase.auth.onAuthStateChange((event, session) => {
+  console.log('auth event', event, session?.user.id);
+});
+
+subscription.unsubscribe();
+```
+
+### Database Queries and RPC
+**Exports**
+- supabase.from
+- supabase.schema
+- supabase.rpc
+
+PostgREST-backed table/view querying and Postgres function calls.
+
+#### supabase.from
+**Kind**
+function
+
+**Summary**
+Start a table or view query against the client’s configured PostgREST schema.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+from(relation: string): PostgrestQueryBuilder<ClientOptions, Schema, any>;
+```
+
+**Guidance**
+- Use this as the main entrypoint for table and view queries.
+- Keep the default schema model in mind: `from(...)` works against the client’s configured schema, which defaults to `public`.
+- Let PostgREST compose the query with chained filters/selects rather than building URLs manually.
+
+**Example**
+Language: typescript
+Description: Select rows from a table.
+
+```ts
+const { data, error } = await supabase
+  .from('profiles')
+  .select('id, username')
+  .order('username', { ascending: true });
+```
+
+#### supabase.schema
+**Kind**
+function
+
+**Summary**
+Return a PostgREST client bound to a different exposed schema for queries and
+RPC calls.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+schema(schema: DynamicSchema): PostgrestClient<Database, ClientOptions, DynamicSchema, any>;
+```
+
+**Guidance**
+- Use this when you need a non-default exposed schema for database or RPC work.
+- The returned object is a PostgREST client, not a full Supabase client; do not expect auth, storage, or functions on it.
+- Prefer `db.schema` at client creation time when one schema is the dominant context for that client.
+
+**Example**
+Language: typescript
+Description: Query a table from another exposed schema.
+
+```ts
+const adminDb = supabase.schema('admin');
+const { data, error } = await adminDb.from('audit_log').select('*');
+```
+
+#### supabase.rpc
+**Kind**
+function
+
+**Summary**
+Call an exposed Postgres function through PostgREST, with optional read-only
+mode and count behavior for set-returning functions.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+rpc(
+  fn: FnName,
+  args?: Args,
+  options?: {
+    head?: boolean;
+    get?: boolean;
+    count?: 'exact' | 'planned' | 'estimated';
+  }
+): PostgrestFilterBuilder<ClientOptions, Schema, Row, Result, RelationName, Relationships, 'RPC'>;
+```
+
+**Guidance**
+- Use RPC for SQL functions you intentionally expose through PostgREST.
+- Treat the RPC name and argument contract as database API surface, not as loose dynamic strings.
+- Use `get: true` only for read-only semantics where the function is designed for GET access.
+- For set-returning functions, the `count` option controls PostgREST count behavior; do not expect it to affect scalar-returning functions.
+
+**Example**
+Language: typescript
+Description: Call an exposed Postgres function with named args.
+
+```ts
+const { data, error } = await supabase.rpc('search_profiles', {
+  query_text: 'ada',
+});
+```
+
+### Storage and File Delivery
+**Exports**
+- supabase.storage
+- supabase.storage.from
+- StorageFileApi.upload
+- StorageFileApi.createSignedUrl
+- StorageFileApi.download
+- StorageFileApi.getPublicUrl
+- StorageFileApi.list
+
+Bucket and file operations for uploads, downloads, signed sharing, and metadata
+listing.
+
+#### supabase.storage
+**Kind**
+object
+
+**Summary**
+The top-level storage client for buckets, files, and related storage APIs.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+storage: SupabaseStorageClient;
+```
+
+**Guidance**
+- Use this namespace for bucket/file work; then narrow into one bucket with `from(bucket)`.
+- The ordinary `supabase-js` guidance centers on file buckets, not the alpha vector or analytics storage APIs.
+- Keep public-asset URLs, signed URLs, and private downloads as separate access patterns.
+
+**Example**
+Language: typescript
+Description: Enter one bucket’s file API.
+
+```ts
+const avatars = supabase.storage.from('avatars');
+```
+
+#### supabase.storage.from
+**Kind**
+function
+
+**Summary**
+Scope storage file operations to a specific bucket.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+from(id: string): StorageFileApi;
+```
+
+**Guidance**
+- Use this before upload, download, signed URL, list, move, copy, or delete operations.
+- Treat the bucket name as part of your application contract and keep it explicit.
+- Prefer storing the returned bucket API in a variable when multiple operations target the same bucket.
+
+**Example**
+Language: typescript
+Description: Reuse one bucket-scoped storage API.
+
+```ts
+const avatars = supabase.storage.from('avatars');
+```
+
+#### StorageFileApi.upload
+**Kind**
+function
+
+**Summary**
+Upload a file body to a path in the selected bucket.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+upload(
+  path: string,
+  fileBody: FileBody,
+  fileOptions?: FileOptions
+): Promise<{ data: { id: string; path: string; fullPath: string } | null; error: StorageError | null }>;
+```
+
+**Guidance**
+- Use this for authenticated uploads into an existing bucket.
+- `path` is the file path inside the bucket, not a full URL.
+- Set `contentType`, `cacheControl`, and `upsert` deliberately; do not leave them ambiguous when file semantics matter.
+
+**Example**
+Language: typescript
+Description: Upload an avatar image to a bucket.
+
+```ts
+const avatarFile = input.files?.[0];
+
+if (avatarFile) {
+  const { data, error } = await supabase
+    .storage
+    .from('avatars')
+    .upload(`public/${avatarFile.name}`, avatarFile, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+}
+```
+
+#### StorageFileApi.createSignedUrl
+**Kind**
+function
+
+**Summary**
+Create a time-limited signed URL for one file in a bucket.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+createSignedUrl(
+  path: string,
+  expiresIn: number,
+  options?: {
+    download?: string | boolean;
+    transform?: TransformOptions;
+  }
+): Promise<{ data: { signedUrl: string } | null; error: StorageError | null }>;
+```
+
+**Guidance**
+- Use this for temporary sharing of private assets.
+- Prefer this over `getPublicUrl(...)` when the bucket is private or the asset should expire.
+- Keep `expiresIn` explicit in seconds and aligned to the actual sharing requirement.
+
+**Example**
+Language: typescript
+Description: Create a one-minute signed URL for a private file.
+
+```ts
+const { data, error } = await supabase
+  .storage
+  .from('avatars')
+  .createSignedUrl('private/avatar.png', 60);
+```
+
+#### StorageFileApi.download
+**Kind**
+function
+
+**Summary**
+Download a file from a private bucket, optionally with transforms or fetch
+parameters.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+download(
+  path: string,
+  options?: { transform?: TransformOptions },
+  parameters?: FetchParameters
+): BlobDownloadBuilder;
+```
+
+**Guidance**
+- Use this for private bucket downloads; for public buckets, the docs recommend using the URL from `getPublicUrl(...)`.
+- In server or edge runtimes, pass fetch parameters such as `cache: 'no-store'` or `signal` when the request semantics matter.
+- Do not treat `download(...)` and `getPublicUrl(...)` as interchangeable.
+
+**Example**
+Language: typescript
+Description: Download a private file without caching.
+
+```ts
+const { data, error } = await supabase
+  .storage
+  .from('avatars')
+  .download('private/avatar.png', {}, { cache: 'no-store' });
+```
+
+#### StorageFileApi.getPublicUrl
+**Kind**
+function
+
+**Summary**
+Construct the public URL for a file in a public bucket.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+getPublicUrl(
+  path: string,
+  options?: {
+    download?: string | boolean;
+    transform?: TransformOptions;
+  }
+): {
+  data: { publicUrl: string };
+};
+```
+
+**Guidance**
+- Use this only when the bucket is intentionally public.
+- This does not verify bucket privacy for you; a generated public URL does not imply the asset is actually retrievable if the bucket is private.
+- Prefer this over `download(...)` for public browser-facing asset delivery.
+
+**Example**
+Language: typescript
+Description: Build a public image URL.
+
+```ts
+const {
+  data: { publicUrl },
+} = supabase.storage.from('public-assets').getPublicUrl('logos/mark.png');
+```
+
+#### StorageFileApi.list
+**Kind**
+function
+
+**Summary**
+List files and folders inside a bucket path.
+
+**Definition**
+Language: typescript
+Source: `@supabase/storage-js@2.99.1` `index.d.mts`
+
+```ts
+list(
+  path?: string,
+  options?: SearchOptions,
+  parameters?: FetchParameters
+): Promise<{ data: FileObject[] | null; error: StorageError | null }>;
+```
+
+**Guidance**
+- Use this for directory-like browsing and search inside a bucket path.
+- Folder entries differ from file entries; several metadata fields are `null` on folders.
+- Keep `limit`, `offset`, and `sortBy` explicit for admin-style UIs and background jobs.
+
+**Example**
+Language: typescript
+Description: List the first 100 files in a folder.
+
+```ts
+const { data, error } = await supabase
+  .storage
+  .from('avatars')
+  .list('public', {
+    limit: 100,
+    offset: 0,
+    sortBy: { column: 'name', order: 'asc' },
+  });
+```
+
+### Realtime Channels and Edge Function Invocation
+**Exports**
+- supabase.channel
+- supabase.getChannels
+- supabase.removeChannel
+- supabase.removeAllChannels
+- supabase.functions
+- FunctionsClient.invoke
+
+Long-lived channel subscriptions plus client-side invocation of deployed Edge
+Functions.
+
+#### supabase.channel
+**Kind**
+function
+
+**Summary**
+Create a Realtime channel for broadcast, presence, or Postgres changes.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+channel(name: string, opts?: RealtimeChannelOptions): RealtimeChannel;
+```
+
+**Guidance**
+- Use one channel per logical subscription surface instead of piling unrelated concerns into one unnamed channel.
+- Keep cleanup explicit with `removeChannel(...)` or `removeAllChannels()` when the runtime/component ends.
+- Realtime requires native `WebSocket` support in browser environments.
+
+**Example**
+Language: typescript
+Description: Create a channel for Postgres changes.
+
+```ts
+const channel = supabase.channel('room-1');
+```
+
+#### supabase.getChannels
+**Kind**
+function
+
+**Summary**
+Return the Realtime channels currently attached to the client.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+getChannels(): RealtimeChannel[];
+```
+
+**Guidance**
+- Use this for diagnostics or cleanup tooling when you suspect channel leakage.
+- Do not treat it as the primary application state source for subscription logic.
+
+**Example**
+Language: typescript
+Description: Inspect active Realtime channels.
+
+```ts
+const channels = supabase.getChannels();
+```
+
+#### supabase.removeChannel
+**Kind**
+function
+
+**Summary**
+Unsubscribe and remove one Realtime channel from the client.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+removeChannel(channel: RealtimeChannel): Promise<'ok' | 'timed out' | 'error'>;
+```
+
+**Guidance**
+- Use this when a specific subscription scope is no longer needed.
+- Always keep the channel reference if you expect to clean it up later.
+
+**Example**
+Language: typescript
+Description: Tear down a specific channel.
+
+```ts
+await supabase.removeChannel(channel);
+```
+
+#### supabase.removeAllChannels
+**Kind**
+function
+
+**Summary**
+Unsubscribe and remove all Realtime channels from the client.
+
+**Definition**
+Language: typescript
+Source: `dist/index.d.mts`
+
+```ts
+removeAllChannels(): Promise<Array<'ok' | 'timed out' | 'error'>>;
+```
+
+**Guidance**
+- Use this at global teardown boundaries such as app shutdown, test cleanup, or explicit logout flows.
+- Prefer `removeChannel(...)` when only one subscription scope is ending.
+
+**Example**
+Language: typescript
+Description: Remove all active channels at teardown.
+
+```ts
+await supabase.removeAllChannels();
+```
+
+#### supabase.functions
+**Kind**
+object
+
+**Summary**
+The edge-function invocation client scoped to the project’s `/functions/v1`
+endpoint.
+
+**Definition**
+Language: typescript
+Source: `src/SupabaseClient.ts`
+
+```ts
+get functions(): FunctionsClient;
+```
+
+**Guidance**
+- Use this namespace to call already deployed Edge Functions from app code.
+- This is not the function-authoring or deployment API; that belongs to your Edge Function source and deployment tooling.
+- The client inherits the Supabase headers and custom fetch configuration.
+
+**Example**
+Language: typescript
+Description: Access the functions client and invoke a function.
+
+```ts
+const { data, error } = await supabase.functions.invoke('hello-world', {
+  body: { name: 'Ada' },
+});
+```
+
+#### FunctionsClient.invoke
+**Kind**
+function
+
+**Summary**
+Invoke a deployed Edge Function by name with optional body and invocation
+options.
+
+**Definition**
+Language: typescript
+Source: `@supabase/functions-js@2.99.1` `FunctionsClient.d.ts`
+
+```ts
+invoke<T = any>(
+  functionName: string,
+  options?: FunctionInvokeOptions
+): Promise<FunctionsResponse<T>>;
+```
+
+**Guidance**
+- Use this when you need server-side logic that runs as a deployed Supabase Edge Function.
+- Keep the function name aligned to the deployed route name, not a file path in your local repo.
+- Treat typed response parsing as an application-level contract; the SDK does not infer your function response shape automatically.
+
+**Example**
+Language: typescript
+Description: Invoke an Edge Function and type the JSON response.
+
+```ts
+type HelloResponse = { message: string };
+
+const { data, error } = await supabase.functions.invoke<HelloResponse>(
+  'hello-world',
+  {
+    body: { name: 'Ada' },
+  }
+);
+```

--- a/website/static/distributions/claude/supabase-js/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/supabase-js/0.4.0/references/overview.md
@@ -1,0 +1,77 @@
+# Supabase JS Overview
+
+## Snapshot
+
+- Spec name: supabase-js
+- Spec version: 0.4.0
+- Generated: 2026-03-16
+- Library version: @supabase/supabase-js^2.99.1
+- Primary language: typescript
+- Homepage: https://supabase.com/docs/reference/javascript/start
+- Source set: stable published `@supabase/supabase-js@2.99.1`; `README.md`; `src/index.ts`; `src/SupabaseClient.ts`; `dist/index.d.mts`; stable published `@supabase/auth-js@2.99.1` `GoTrueClient.d.ts`; stable published `@supabase/functions-js@2.99.1` `FunctionsClient.d.ts`; stable published `@supabase/storage-js@2.99.1` `index.d.mts`; and `parse/supabase-js-docs-v0.4.0.md`
+
+**Tags**
+- supabase-js
+- supabase
+- auth
+- storage
+- realtime
+- edge-functions
+
+## Purpose
+
+This pack teaches an agent to use `@supabase/supabase-js` as the isomorphic
+JavaScript client for Supabase services: initialize the client correctly for the
+target runtime, use auth/session APIs with the right trust model, query PostgREST
+tables and RPC functions, manage storage buckets and files, subscribe to
+Realtime channels, and invoke deployed Edge Functions without confusing client
+SDK usage with dashboard configuration or server-side authoring workflows.
+
+## Guiding Principles
+
+- Treat `createClient(...)` as the entrypoint; the returned client composes auth, database, storage, functions, and realtime.
+- Prefer the stable published npm surface over upstream `master` drift when they diverge.
+- Keep auth, database, storage, realtime, and functions mentally separate even though they share one client.
+- Use `getUser()` for authentic user identity on trusted-server decisions; `getSession()` reads local storage state and has weaker guarantees.
+- Treat `accessToken` mode as mutually exclusive with `supabase.auth`.
+- Use `from(...)` for table/view queries and `rpc(...)` for Postgres functions.
+- Use `storage.from(bucket)` to enter file operations; distinguish public URLs, signed URLs, and private downloads explicitly.
+- Treat `functions.invoke(...)` as the client-side invocation surface for already deployed Edge Functions, not as the function authoring workflow.
+- Prefer runtime-specific configuration only where needed: custom `fetch`, React Native storage, headers, or schema selection.
+- Keep this pack aligned to Node 20+ support for current versions of `@supabase/supabase-js`.
+
+## Boundary Notes
+
+- The stable package line is `2.99.1`, while the upstream repo `master` branch continues to move; this pack is anchored to the published package and stable dependency types.
+- `@supabase/supabase-js` is a composition layer over `auth-js`, `postgrest-js`, `storage-js`, `functions-js`, and `realtime-js`; the pack documents the top-level client surface plus the most important delegated methods.
+- Framework helpers such as `@supabase/ssr` are out of scope here; this pack is for the core JS client.
+- Edge Function authoring, deployment, and server runtime code are out of scope here; `supabase.functions.invoke(...)` is the relevant client surface.
+- Storage vectors and analytics are present in `storage-js`, but they are alpha surfaces and are not first-line guidance for ordinary `supabase-js` work.
+- Runtime support matters operationally: browsers need native `fetch` and Realtime also needs native `WebSocket`; current `supabase-js` requires Node 20+.
+
+## FAQ
+
+### Should I use `getSession()` or `getUser()`?
+- Use `getSession()` for normal client-side session access.
+- Use `getUser()` when you need authenticated identity you can trust for server-side authorization decisions.
+
+### Should I set `db.schema` or call `schema(...)`?
+- Set `db.schema` when one schema should be the default for the whole client.
+- Call `schema(...)` when you need a different PostgREST client for a specific query/RPC flow.
+
+### Is `supabase.functions.invoke(...)` how I write Edge Functions?
+- No.
+- It is the client-side invocation surface for functions that are already deployed.
+- Function authoring, runtime code, and deployment are outside this package’s core API.
+
+### Does this pack cover framework-specific helpers like `@supabase/ssr`?
+- No.
+- This pack is for `@supabase/supabase-js` itself.
+- SSR helpers and framework wrappers should be treated as separate surfaces.
+
+## External Resources
+
+- Supabase JavaScript reference: https://supabase.com/docs/reference/javascript/start
+- Supabase JS repository: https://github.com/supabase/supabase-js
+- Supabase Auth JS repository: https://github.com/supabase/auth-js
+- Supabase Storage JS repository: https://github.com/supabase/storage-js

--- a/website/static/distributions/claude/supabase-js/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/supabase-js/0.4.0/references/troubleshooting.md
@@ -1,0 +1,46 @@
+# Supabase JS Troubleshooting
+
+### `supabase.auth` throws when I touch it
+**Cause**
+- The client was created with the `accessToken` option.
+- The docs explicitly say that when `accessToken` is set, the `auth` namespace cannot be used on that client.
+
+**Fix**
+- Create one client for third-party token mode and a separate client for built-in Supabase Auth if you need both behaviors.
+- Remove `accessToken` from the client options if Supabase Auth should be the active session model.
+
+### `getSession()` works locally, but I do not trust it on the server
+**Cause**
+- `getSession()` reads from the attached storage.
+- In server-like environments, storage-backed session values may not be authentic enough for trusted authorization decisions.
+
+**Fix**
+- Use `getUser()` when you need verified identity from the Auth server.
+- Reserve `getSession()` for ordinary client-side session access or non-authoritative UI state.
+
+### Realtime subscriptions do not work in this environment
+**Cause**
+- The runtime does not provide the primitives Realtime expects, especially native `WebSocket`.
+- Browser-like contexts also need native `fetch`.
+
+**Fix**
+- Fix the runtime environment or polyfill boundary before debugging the subscription logic itself.
+- Re-test channel creation only after confirming the runtime supports the required APIs.
+
+### A file URL exists, but the file still is not accessible
+**Cause**
+- `getPublicUrl(...)` was used for a bucket that is not actually public.
+- The SDK constructs the URL but does not verify bucket privacy for you.
+
+**Fix**
+- Use `createSignedUrl(...)` for temporary access to private objects.
+- Use `download(...)` when you need authenticated retrieval instead of a shareable URL.
+
+### `onAuthStateChange` causes odd hangs or deadlock-like behavior
+**Cause**
+- The callback is async or triggers work that contends with the auth client’s exclusive lock.
+- The auth package explicitly warns that async callbacks can deadlock.
+
+**Fix**
+- Keep the `onAuthStateChange(...)` callback synchronous.
+- Hand off async work outside the subscription callback instead of awaiting inside it.

--- a/website/static/distributions/claude/supabase-js/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/supabase-js/0.4.0/references/workflows.md
@@ -1,0 +1,32 @@
+# Supabase JS Workflows
+
+### Create a client for the right runtime
+1. Start with `createClient(url, publishableKey)`.
+2. Add `global.fetch` only when the runtime fetch implementation is the compatibility boundary.
+3. Add React Native auth storage explicitly when the runtime does not provide the right persistence behavior by default.
+4. Use `db.schema` only when one non-public schema is your dominant query surface.
+
+### Authenticate a user and load trustworthy identity
+1. Use `supabase.auth.signInWithPassword(...)`, OAuth, or OTP methods for the sign-in flow that matches the app.
+2. Use `getSession()` for ordinary client session access.
+3. Use `getUser()` when server-side trust or authorization decisions depend on authentic user identity.
+4. Subscribe with `onAuthStateChange(...)` using a synchronous callback.
+
+### Query tables or call database functions
+1. Use `from(...)` for tables and views in the client’s configured schema.
+2. Use `schema(...)` when you need another exposed schema for PostgREST or RPC work.
+3. Use `rpc(...)` for exposed Postgres functions rather than trying to call `/rest/v1/rpc/...` manually.
+4. Use `QueryData<typeof query>` when you want inferred result types from a built query.
+
+### Upload, share, or fetch files
+1. Enter the bucket with `supabase.storage.from('bucket')`.
+2. Use `upload(...)` or `update(...)` for writes.
+3. Use `getPublicUrl(...)` only for public buckets.
+4. Use `createSignedUrl(...)` for temporary access to private files.
+5. Use `download(...)` for private content retrieval, especially in server or edge runtimes.
+
+### Subscribe to changes and invoke deployed functions
+1. Create a named channel with `supabase.channel(...)`.
+2. Clean up with `removeChannel(...)` or `removeAllChannels()`.
+3. Use `supabase.functions.invoke(...)` to call deployed Edge Functions.
+4. Keep Realtime and Functions mentally separate: one is long-lived subscription transport, the other is request/response execution.

--- a/website/static/distributions/claude/typescript/0.4.0/SKILL.md
+++ b/website/static/distributions/claude/typescript/0.4.0/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: typescript
+description: Use for TypeScript typing, configuration, generics, and API-design tasks. Helps with compiler behavior, type modeling, and debugging decisions.
+---
+
+# TypeScript
+
+Use this skill when the task depends on TypeScript-specific typing or compiler behavior rather than generic JavaScript guidance.
+
+## Purpose
+
+This pack teaches an agent to use TypeScript 5.9 effectively for generic API design, narrowing, inference, utility types, module-resolution debugging, and `tsconfig` decisions while keeping language semantics, compiler behavior, and runtime behavior clearly separated.
+
+## When to use this skill
+
+- type modeling and API design
+- tsconfig and compiler configuration
+- generics, inference, and narrowing
+- type-level debugging and refactoring
+
+## Working style
+
+- Treat TypeScript as a static-analysis and type-modeling system, not as runtime validation.
+- Use generics only when they express a real relationship between inputs and outputs.
+- Prefer narrowing and discriminated unions over repeated assertions.
+
+## Read next
+
+- For overview and boundaries: `references/overview.md`
+- For the core API surface: `references/api-groups.md`
+- For common workflows: `references/workflows.md`
+- For debugging and fixes: `references/troubleshooting.md`

--- a/website/static/distributions/claude/typescript/0.4.0/manifest.json
+++ b/website/static/distributions/claude/typescript/0.4.0/manifest.json
@@ -1,0 +1,17 @@
+{
+  "tool_id": "typescript",
+  "version": "0.4.0",
+  "distribution": "claude",
+  "entrypoint": "SKILL.md",
+  "generated_from": "agents/typescript/0.4.0.md",
+  "display_name": "TypeScript",
+  "description": "Use for TypeScript typing, configuration, generics, and API-design tasks. Helps with compiler behavior, type modeling, and debugging decisions.",
+  "files": [
+    "manifest.json",
+    "references/api-groups.md",
+    "references/overview.md",
+    "references/troubleshooting.md",
+    "references/workflows.md",
+    "SKILL.md"
+  ]
+}

--- a/website/static/distributions/claude/typescript/0.4.0/references/api-groups.md
+++ b/website/static/distributions/claude/typescript/0.4.0/references/api-groups.md
@@ -1,0 +1,580 @@
+# TypeScript API Groups
+
+### Type Relationships
+**Exports**
+- Generics
+- keyof
+- Conditional Types
+- infer
+- satisfies
+
+Core TypeScript constructs for expressing relationships between values, types, and derived types.
+
+#### Generics
+**Kind**
+type
+
+**Summary**
+Generic parameters let one function, type, or interface express a type relationship across multiple positions.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/generics.html
+
+```ts
+function identity<T>(value: T): T;
+type Box<T> = { value: T };
+```
+
+**Guidance**
+- Use generics when the output type or callback type must track the input type.
+- Avoid adding generic parameters that do not constrain or derive anything.
+- Preserve inference by letting values drive generic arguments whenever practical.
+
+**Example**
+Language: typescript
+Description: A generic helper that preserves the element type through the callback.
+
+```ts
+function mapValues<T, R>(
+  values: readonly T[],
+  mapper: (value: T, index: number) => R,
+): R[] {
+  return values.map(mapper);
+}
+```
+
+#### keyof
+**Kind**
+other
+
+**Summary**
+`keyof` produces the union of valid property keys for a type.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/keyof-types.html
+
+```ts
+type Keys<T> = keyof T;
+```
+
+**Guidance**
+- Use `keyof` to constrain property-name parameters or derive key unions from source types.
+- Combine with indexed access types like `T[K]` to keep property access type-safe.
+- Remember that index signatures widen the resulting key union.
+
+**Example**
+Language: typescript
+Description: A property reader that only accepts valid keys.
+
+```ts
+function getProp<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+```
+
+#### Conditional Types
+**Kind**
+type
+
+**Summary**
+Conditional types choose one result type or another based on assignability.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
+
+```ts
+type Result<T> = T extends SomeConstraint ? A : B;
+```
+
+**Guidance**
+- Use conditional types when a type-level output genuinely depends on a type-level input.
+- Watch for distributive behavior when the checked type is a naked type parameter.
+- Split deep conditional logic into named helpers before it becomes unreadable.
+
+**Example**
+Language: typescript
+Description: Extract a `message` property when the shape supports it.
+
+```ts
+type MessageOf<T> = T extends { message: unknown } ? T["message"] : never;
+```
+
+#### infer
+**Kind**
+other
+
+**Summary**
+`infer` introduces a type variable inside a conditional type so structure can be extracted from another type.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
+
+```ts
+type ElementType<T> = T extends Array<infer U> ? U : T;
+```
+
+**Guidance**
+- Use `infer` inside conditional types when you need to pull out a nested type from an existing shape.
+- Keep `infer` helpers small and specific so the extracted type is obvious to readers.
+- If the resulting conditional type becomes opaque, break it into named intermediate helpers.
+
+**Example**
+Language: typescript
+Description: Derive the resolved value type from an async function.
+
+```ts
+type AsyncValue<T> = T extends Promise<infer U> ? U : T;
+```
+
+#### satisfies
+**Kind**
+other
+
+**Summary**
+`satisfies` checks that a value conforms to a target type without widening the value to that type.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator
+
+```ts
+const routes = {
+  home: "/",
+  about: "/about",
+} satisfies Record<string, `/${string}`>;
+```
+
+**Guidance**
+- Use `satisfies` when you want shape-checking but also want to preserve narrow literal inference.
+- Prefer it over broad `as SomeType` assertions for config-like objects and constant maps.
+- It changes checking only; it does not change runtime values or runtime validation.
+
+**Example**
+Language: typescript
+Description: Validate a config object shape while preserving specific literal values.
+
+```ts
+const config = {
+  mode: "strict",
+  retries: 3,
+} satisfies { mode: "strict" | "loose"; retries: number };
+```
+
+### Narrowing and Soundness
+**Exports**
+- unknown
+- Type Predicates
+- Discriminated Unions
+
+High-value primitives for turning uncertain values into safely usable values.
+
+#### unknown
+**Kind**
+type
+
+**Summary**
+`unknown` represents a value whose type is not yet trusted and must be narrowed before specific use.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown
+
+```ts
+let value: unknown;
+```
+
+**Guidance**
+- Use `unknown` at trust boundaries such as JSON, request input, environment data, or third-party outputs.
+- Narrow it with `typeof`, `instanceof`, discriminants, or type predicates before property access or function calls.
+- Prefer it over `any` when the data is genuinely unknown.
+
+**Example**
+Language: typescript
+Description: Narrow an untrusted input into a usable port value.
+
+```ts
+function parsePort(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Number(value);
+  throw new Error("Expected a string or number");
+}
+```
+
+#### Type Predicates
+**Kind**
+other
+
+**Summary**
+A type predicate tells the compiler what a successful runtime check proves about a value.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates
+
+```ts
+function isFoo(value: unknown): value is Foo;
+```
+
+**Guidance**
+- Use type predicates when the same narrowing logic is reused across multiple call sites.
+- Make the runtime check honest; a lying predicate makes downstream code unsound.
+- Prefer small, targeted predicates over one giant validator with vague semantics.
+
+**Example**
+Language: typescript
+Description: Reuse a guard for values that should look like a user object.
+
+```ts
+type User = { id: string; name: string };
+
+function isUser(value: unknown): value is User {
+  return !!value &&
+    typeof value === "object" &&
+    "id" in value &&
+    "name" in value;
+}
+```
+
+#### Discriminated Unions
+**Kind**
+type
+
+**Summary**
+A discriminated union uses a shared literal field so control flow can narrow reliably by branch.
+
+**Definition**
+Language: typescript
+Source: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
+
+```ts
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "square"; sideLength: number };
+```
+
+**Guidance**
+- Use a stable discriminant such as `kind`, `type`, or `status` across all union members.
+- Prefer discriminants over structural guessing when branches need precise narrowing.
+- Exhaustive `switch` statements scale better than chains of assertions when unions grow.
+
+**Example**
+Language: typescript
+Description: Compute area with branch-safe access to shape-specific fields.
+
+```ts
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2;
+    case "square":
+      return shape.sideLength ** 2;
+  }
+}
+```
+
+### Built-in Utility Types
+**Exports**
+- Partial
+- Omit
+- ReturnType
+- Awaited
+
+Standard-library helpers that encode common type transformations.
+
+#### Partial
+**Kind**
+type
+
+**Summary**
+`Partial<T>` makes every property on `T` optional.
+
+**Definition**
+Language: typescript
+Source: npm:typescript@5.9.3:package/lib/lib.es5.d.ts
+
+```ts
+type Partial<T> = {
+  [P in keyof T]?: T[P];
+};
+```
+
+**Guidance**
+- Use for patch-style updates or builder-like APIs where omission is meaningful.
+- Do not use it as a blanket replacement for domain-specific input models that require runtime guarantees.
+- Remember that optional properties can still exist with an `undefined` value.
+
+**Example**
+Language: typescript
+Description: Model a user patch shape without duplicating every field.
+
+```ts
+type User = { id: string; name: string; email: string };
+type UserPatch = Partial<User>;
+```
+
+#### Omit
+**Kind**
+type
+
+**Summary**
+`Omit<T, K>` removes a set of keys from `T`.
+
+**Definition**
+Language: typescript
+Source: npm:typescript@5.9.3:package/lib/lib.es5.d.ts
+
+```ts
+type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+```
+
+**Guidance**
+- Use when you want to derive a public or input-facing shape from a richer source type.
+- Prefer `Omit` over hand-copied derivative interfaces that will drift from the source.
+- Keep the omitted-key set explicit and reviewable.
+
+**Example**
+Language: typescript
+Description: Remove a sensitive field from a user type.
+
+```ts
+type User = { id: string; name: string; passwordHash: string };
+type PublicUser = Omit<User, "passwordHash">;
+```
+
+#### ReturnType
+**Kind**
+type
+
+**Summary**
+`ReturnType<T>` extracts the return type from a function type.
+
+**Definition**
+Language: typescript
+Source: npm:typescript@5.9.3:package/lib/lib.es5.d.ts
+
+```ts
+type ReturnType<T extends (...args: any) => any> =
+  T extends (...args: any) => infer R ? R : any;
+```
+
+**Guidance**
+- Use when a function signature is the single source of truth for the produced value.
+- Prefer it over repeating object shapes in multiple places.
+- Be careful with function unions whose extracted return type may become too broad.
+
+**Example**
+Language: typescript
+Description: Derive a config type from a factory function.
+
+```ts
+function buildConfig() {
+  return { strict: true, noEmit: true };
+}
+
+type BuildConfig = ReturnType<typeof buildConfig>;
+```
+
+#### Awaited
+**Kind**
+type
+
+**Summary**
+`Awaited<T>` recursively unwraps promise-like values using the same model as `await`.
+
+**Definition**
+Language: typescript
+Source: npm:typescript@5.9.3:package/lib/lib.es5.d.ts
+
+```ts
+type Awaited<T> =
+  T extends null | undefined ? T :
+  T extends object & { then(onfulfilled: infer F, ...args: infer _): any; } ?
+    F extends ((value: infer V, ...args: infer _) => any) ? Awaited<V> : never :
+  T;
+```
+
+**Guidance**
+- Use for async helpers that need the resolved value type of a promise-returning function or promise-like value.
+- Prefer it over home-grown promise-unwrapping helpers when the built-in behavior matches the need.
+- Remember that it recursively unwraps nested promise-like structures.
+
+**Example**
+Language: typescript
+Description: Derive the resolved type from an async loader.
+
+```ts
+async function loadUser() {
+  return { id: "u1", name: "Ada" };
+}
+
+type LoadedUser = Awaited<ReturnType<typeof loadUser>>;
+```
+
+### Compiler Configuration
+**Exports**
+- strict
+- moduleResolution
+- paths
+- noEmit
+
+Compiler options with outsized impact on correctness, imports, and build flow.
+
+#### strict
+**Kind**
+config
+
+**Summary**
+`strict` enables the main family of TypeScript strictness checks as a single baseline switch.
+
+**Definition**
+Language: json
+Source: https://www.typescriptlang.org/tsconfig#strict
+
+```json
+{
+  "compilerOptions": {
+    "strict": true
+  }
+}
+```
+
+**Guidance**
+- Use this as the default baseline unless the repo is in a staged migration.
+- Expect stricter checking around nullability, parameter compatibility, and unchecked assumptions.
+- Prefer explicit, local opt-outs over globally disabling strictness.
+
+**Example**
+Language: json
+Description: A small strict type-checking baseline for application code.
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true
+  }
+}
+```
+
+#### moduleResolution
+**Kind**
+config
+
+**Summary**
+`moduleResolution` chooses how the compiler resolves import specifiers and packages.
+
+**Definition**
+Language: json
+Source: https://www.typescriptlang.org/tsconfig#moduleResolution
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+**Guidance**
+- Match this setting to the actual environment: bundler, Node.js hybrid package rules, or another supported resolver model.
+- Do not assume `module` alone chooses the correct lookup behavior.
+- Many import and declaration errors come from a mismatch between compiler assumptions and the real runtime or bundler.
+
+**Example**
+Language: json
+Description: A bundler-oriented modern ESM setup.
+
+```json
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+#### paths
+**Kind**
+config
+
+**Summary**
+`paths` remaps module specifiers for compiler lookup relative to project structure.
+
+**Definition**
+Language: json
+Source: https://www.typescriptlang.org/tsconfig#paths
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}
+```
+
+**Guidance**
+- Use only when the rest of the toolchain or runtime agrees on the same alias rules.
+- Remember that `paths` affects TypeScript resolution, not emitted runtime specifiers.
+- Keep aliases simple and obvious; wide alias schemes are hard to debug.
+
+**Example**
+Language: json
+Description: Align two simple aliases with a `src`-based project layout.
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@lib/*": ["src/lib/*"]
+    }
+  }
+}
+```
+
+#### noEmit
+**Kind**
+config
+
+**Summary**
+`noEmit` tells the compiler to type-check without writing output files.
+
+**Definition**
+Language: json
+Source: https://www.typescriptlang.org/tsconfig#noEmit
+
+```json
+{
+  "compilerOptions": {
+    "noEmit": true
+  }
+}
+```
+
+**Guidance**
+- Use when another tool emits JavaScript and `tsc` is only responsible for correctness checks.
+- Prefer this in CI or editor-driven workflows where emitted output would be discarded.
+- It changes emission only; it does not reduce the scope of checking.
+
+**Example**
+Language: json
+Description: A type-check-only compiler setup for bundler-managed builds.
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }
+}
+```

--- a/website/static/distributions/claude/typescript/0.4.0/references/overview.md
+++ b/website/static/distributions/claude/typescript/0.4.0/references/overview.md
@@ -1,0 +1,64 @@
+# TypeScript Overview
+
+## Snapshot
+
+- Spec name: typescript
+- Spec version: 0.4.0
+- Generated: 2026-03-12
+- Library version: ^5.9.3
+- Primary language: typescript
+- Homepage: https://www.typescriptlang.org/docs/
+- Source set: npm:typescript@5.9.3 standard library declarations, official handbook pages, official TSConfig reference pages, TypeScript release notes for `satisfies`, parse/tsconfig.json as a local config anchor, and parse/typescript-docs-v0.4.0.md as the intermediate documentation pack
+
+**Tags**
+- typescript
+- type-system
+- compiler
+- tsconfig
+- generics
+- module-resolution
+- inference
+
+## Purpose
+
+This pack teaches an agent to use TypeScript 5.9 effectively for generic API design, narrowing, inference, utility types, module-resolution debugging, and `tsconfig` decisions while keeping language semantics, compiler behavior, and runtime behavior clearly separated.
+
+## Guiding Principles
+
+- Treat TypeScript as a static-analysis and type-modeling system, not as runtime validation.
+- Use generics only when they express a real relationship between inputs and outputs.
+- Prefer narrowing and discriminated unions over repeated assertions.
+- Use `unknown` at trust boundaries and convert it into specific types with proof.
+- Let inference do work before adding explicit annotations that may over-constrain a design.
+- Match `moduleResolution` and path aliasing to the real runtime or bundler instead of assuming compiler settings alone solve import problems.
+- Prefer `strict: true` unless there is a deliberate migration reason not to.
+
+## Boundary Notes
+
+- Source material: official TypeScript handbook pages for generics, `keyof`, conditional types, narrowing, and the `satisfies` operator; official TSConfig reference pages for `strict`, `moduleResolution`, `paths`, and `noEmit`; and `npm:typescript@5.9.3:package/lib/lib.es5.d.ts` for utility-type contracts.
+- Coverage is intentionally centered on high-value TypeScript language and compiler behavior rather than the compiler API or language-service internals.
+- The pack treats language constructs, utility types, and compiler options as first-class primitives because they are the most useful surfaces for agent task performance in ordinary TypeScript repos.
+- `parse/tsconfig.json` was used only as a small local anchor for config examples, not as the primary contract source.
+- The strongest boundary in this pack is between type-system guarantees and runtime guarantees; many real task failures come from collapsing those two.
+
+## FAQ
+
+### Should I use `any` or `unknown` for external input?
+Use `unknown` unless you deliberately want to opt out of checking. `unknown` keeps the boundary honest and forces narrowing.
+
+### Does `paths` rewrite imports in emitted JavaScript?
+No. It changes TypeScript’s lookup behavior. The runtime or bundler still needs matching alias support.
+
+### Is `satisfies` the same as `as`?
+No. `satisfies` checks compatibility while preserving specific inference. `as` asserts a type without proof.
+
+### Should I annotate every intermediate variable?
+No. Prefer inference unless an explicit annotation improves clarity, constrains a public contract, or prevents unintended widening.
+
+## External Resources
+
+- Generics handbook: https://www.typescriptlang.org/docs/handbook/2/generics.html
+- keyof handbook: https://www.typescriptlang.org/docs/handbook/2/keyof-types.html
+- Conditional types handbook: https://www.typescriptlang.org/docs/handbook/2/conditional-types.html
+- Narrowing handbook: https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+- TSConfig reference: https://www.typescriptlang.org/tsconfig

--- a/website/static/distributions/claude/typescript/0.4.0/references/troubleshooting.md
+++ b/website/static/distributions/claude/typescript/0.4.0/references/troubleshooting.md
@@ -1,0 +1,29 @@
+# TypeScript Troubleshooting
+
+### Property access fails on a union
+**Cause**
+- The branch has not narrowed to a shape that definitely owns the property.
+
+**Fix**
+- Inspect the union members, identify the missing proof, and add a discriminant check, `typeof`, `instanceof`, or a user-defined type predicate.
+
+### Path aliases work in the editor but fail in the running app
+**Cause**
+- `paths` was configured in TypeScript but not mirrored in the runtime or bundler.
+
+**Fix**
+- Inspect emitted imports and runtime resolver configuration, then align the runtime alias configuration or stop using the alias.
+
+### A generic helper returns a wide or useless type
+**Cause**
+- The type relationship is not encoded in both input and output positions.
+
+**Fix**
+- Inspect whether each generic parameter participates in a meaningful relationship, then simplify the signature so inference can re-derive the type arguments.
+
+### Compiler errors changed after enabling strict mode
+**Cause**
+- Latent nullability, unchecked indexing, or incompatible function assumptions were previously hidden.
+
+**Fix**
+- Inspect which strict-mode rule category the error comes from, repair the actual type design, or add a narrow local escape hatch instead of disabling `strict`.

--- a/website/static/distributions/claude/typescript/0.4.0/references/workflows.md
+++ b/website/static/distributions/claude/typescript/0.4.0/references/workflows.md
@@ -1,0 +1,72 @@
+# TypeScript Workflows
+
+### Write a generic helper that preserves inference
+- Use this when a helper’s output type should track its input type or callback output automatically.
+1. Identify the true type relationship between arguments and return value.
+2. Encode that relationship with one or two focused generic parameters.
+3. Let the compiler infer generic arguments from the call site.
+4. Avoid `any` and broad assertions that erase the relationship.
+- Common failure points:
+  - adding unused generic parameters
+  - annotating callback arguments too broadly
+  - forcing explicit type arguments when inference was already sufficient
+
+```ts
+function groupBy<T, K extends PropertyKey>(
+  values: readonly T[],
+  getKey: (value: T) => K,
+): Record<K, T[]> {
+  return values.reduce((acc, value) => {
+    const key = getKey(value);
+    (acc[key] ??= []).push(value);
+    return acc;
+  }, {} as Record<K, T[]>);
+}
+```
+
+### Debug a narrowing failure without assertions
+- Use this when the compiler still sees a union or `unknown` where your code expects one branch.
+1. Identify what branches the compiler still thinks are possible.
+2. Add a discriminant check, `typeof`, `instanceof`, or a type predicate.
+3. Move repeated narrowing logic into a reusable predicate when needed.
+4. Remove unnecessary assertions after the proof exists.
+- Common failure points:
+  - checking a property that is not a stable discriminant
+  - hiding the real problem with `as`
+  - forgetting that `unknown` must be narrowed before use
+
+```ts
+type ApiResult =
+  | { ok: true; data: { id: string } }
+  | { ok: false; error: string };
+
+function readId(result: ApiResult): string | undefined {
+  return result.ok ? result.data.id : undefined;
+}
+```
+
+### Configure a type-check-only project with path aliases
+- Use this when a bundler or runtime handles output and TypeScript should focus on checking.
+1. Enable `strict`.
+2. Set `noEmit: true`.
+3. Choose `moduleResolution` to match the real environment.
+4. Add `paths` only when the runtime or bundler is configured for the same aliases.
+- Common failure points:
+  - editor imports resolving while runtime imports fail
+  - mixing `paths` with an incompatible runtime resolution model
+  - assuming `module` implies the right `moduleResolution`
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noEmit": true
+  }
+}
+```


### PR DESCRIPTION
## Summary

This PR implements PR 3 from issue #13 on top of PR #15.

It makes the website distribution-aware while preserving the current canonical Markdown pack browsing flow.

## What changed

- updated `scripts/sync-agents-static.js` to:
  - sync `distributions/` into website static assets
  - generate `website/src/generated/distribution-index.json`
  - parse canonical `0.4.0` pack metadata for better display on the site
- updated `/agents` to surface Claude-compatible skill availability per pack
- added a new `/agents/skill` route for inspecting generated skill bundles
- added a skill bundle viewer with:
  - rendered `SKILL.md`
  - supporting file list
  - selected file rendering
  - canonical-pack linkout and file download affordances
- added supporting utility and styling updates

## Validation

- `node scripts/sync-agents-static.js`
- `npm run build`

## Notes

- canonical `/agents/spec` flow remains intact
- this PR does not change MCP behavior
- PR remains stacked on the compiler work in #15

Refs #13
