### PR TITLE
Add MCP support for Claude-compatible skill distributions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   directory = "netlify/functions"
 
 [functions."mcp"]
-  included_files = ["agents/**"]
+  included_files = ["agents/**", "distributions/**"]
 
 [[redirects]]
   from = "/.well-known/mcp/health"

--- a/netlify/AGENTS.md
+++ b/netlify/AGENTS.md
@@ -1,6 +1,6 @@
 # MCP Server on Netlify — Minimal HTTP Setup
 
-This repo exposes a minimal, standard MCP server using Netlify Functions and the official MCP SDK’s Streamable HTTP transport. It serves a small, stable tool surface to browse and fetch versioned agent Markdown files from `agents/**`.
+This repo exposes a minimal, standard MCP server using Netlify Functions and the official MCP SDK’s Streamable HTTP transport. It serves a small, stable tool surface to browse and fetch versioned agent Markdown files from `agents/**` and generated Claude-compatible skill bundles from `distributions/claude/**`.
 
 Key files:
 - `netlify/functions/mcp.js:1` — Streamable HTTP MCP server (SDK)
@@ -16,6 +16,9 @@ Key files:
     - `agenthub_list` — args `{ q?: string, limit?: number, offset?: number }`; returns a JSON page of `{ tool_id, versions }`.
     - `agenthub_versions` — args `{ tool_id }`; returns `{ tool_id, versions }`.
     - `agenthub_fetch` — args `{ tool_id, version?: string|'latest' }`; returns raw spec text.
+    - `agenthub_distributions` — args `{ tool_id, version?: string|'latest' }`; returns available generated distributions for that tool/version.
+    - `agenthub_fetch_distribution` — args `{ tool_id, version?: string|'latest', distribution?: string }`; returns a machine-readable distribution bundle with file contents.
+    - `agenthub_fetch_distribution_file` — args `{ tool_id, version?: string|'latest', distribution?: string, file_path }`; returns raw file text from a generated bundle.
     - `agenthub_docs` — returns server/tool docs as JSON.
 
 
@@ -34,6 +37,18 @@ agents/
 - `listTools` is built from the folders present in `agents/`.
 - `getToolManifest` and `runTool` read versions by filename (without `.md`).
 - `runTool` with `version: "latest"` sorts versions lexicographically descending and returns the first one.
+
+Generated Claude-compatible skills live in:
+
+```
+distributions/
+  claude/
+    <tool_id>/
+      <version>/
+        SKILL.md
+        references/
+        manifest.json
+```
 
 
 ## Quick Start (Local Dev)
@@ -68,8 +83,8 @@ curl -sS -X POST http://localhost:8888/mcp \
 
 ## JSON‑RPC Methods (via SDK)
 
-- tools/list → returns 4 tools
-- tools/call → routes to `agenthub_list`, `agenthub_versions`, `agenthub_fetch`, `agenthub_docs`
+- tools/list → returns 7 tools
+- tools/call → routes to `agenthub_list`, `agenthub_versions`, `agenthub_fetch`, `agenthub_distributions`, `agenthub_fetch_distribution`, `agenthub_fetch_distribution_file`, `agenthub_docs`
 
 
 SSE is not required in this minimal setup.
@@ -78,7 +93,7 @@ SSE is not required in this minimal setup.
 ## Deployment Notes
 
 - `export const config = { path: "/mcp" }` in `netlify/functions/mcp.js:1` exposes `/mcp` directly.
-- `[functions."mcp"].included_files = ["agents/**"]` ensures the Markdown agents ship with the function bundle.
+- `[functions."mcp"].included_files = ["agents/**", "distributions/**"]` ensures both canonical packs and generated skill bundles ship with the function bundle.
 - Push to a Netlify‑connected repo, or build locally with `npm run build` and let Netlify CI run the same.
 
 - GET `/.well-known/mcp/health`

--- a/netlify/functions/mcp.js
+++ b/netlify/functions/mcp.js
@@ -149,6 +149,10 @@ export const config = { path: "/mcp" };
 
 async function buildServer({ McpServer, z, fs, path, AGENTS_DIR }) {
   const server = new McpServer({ name: "agent-hub", version: "1.1.0" }, { capabilities: { logging: {} } });
+  const DISTRIBUTIONS_DIR = path.join(process.cwd(), "distributions", "claude");
+  const DISTRIBUTION_LABELS = {
+    claude: "Claude-compatible skill"
+  };
 
   // Register tools using the config API so inputSchema is honored (raw Zod shape)
   server.registerTool(
@@ -233,6 +237,108 @@ async function buildServer({ McpServer, z, fs, path, AGENTS_DIR }) {
     }
   );
 
+  // Chosen PR 4 design: add new distribution-specific tools instead of changing
+  // the existing pack tools. This preserves backward compatibility for current
+  // Markdown-pack clients while exposing generated Claude-compatible bundles.
+  server.registerTool(
+    "agenthub_distributions",
+    {
+      title: "AgentHub: List Distributions",
+      description:
+        "List available distributions for a tool_id and version.\n" +
+        "- version: string or 'latest' (default 'latest').\n" +
+        "Returns JSON text: { tool_id, version, distributions: [{ distribution, label, entrypoint, files, description }] }.",
+      inputSchema: {
+        tool_id: z.string().describe("Tool folder under agents/"),
+        version: z.string().optional().default("latest")
+      }
+    },
+    async ({ tool_id, version = "latest" }) => {
+      const selectedVersion = await resolveVersion({ fs, path, AGENTS_DIR, tool_id, version });
+      const distributions = await listDistributions({
+        fs,
+        path,
+        DISTRIBUTIONS_DIR,
+        tool_id,
+        version: selectedVersion,
+        distributionLabels: DISTRIBUTION_LABELS
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ tool_id, version: selectedVersion, distributions }, null, 2)
+          }
+        ]
+      };
+    }
+  );
+
+  server.registerTool(
+    "agenthub_fetch_distribution",
+    {
+      title: "AgentHub: Fetch Distribution",
+      description:
+        "Fetch a generated distribution bundle for a tool_id and version.\n" +
+        "- version: string or 'latest' (default 'latest').\n" +
+        "- distribution: distribution slug (default 'claude').\n" +
+        "Returns JSON text with entrypoint and file contents.",
+      inputSchema: {
+        tool_id: z.string().describe("Tool folder under agents/"),
+        version: z.string().optional().default("latest"),
+        distribution: z.string().optional().default("claude")
+      }
+    },
+    async ({ tool_id, version = "latest", distribution = "claude" }) => {
+      const selectedVersion = await resolveVersion({ fs, path, AGENTS_DIR, tool_id, version });
+      const bundle = await readDistributionBundle({
+        fs,
+        path,
+        DISTRIBUTIONS_DIR,
+        tool_id,
+        version: selectedVersion,
+        distribution,
+        distributionLabels: DISTRIBUTION_LABELS
+      });
+
+      return { content: [{ type: "text", text: JSON.stringify(bundle, null, 2) }] };
+    }
+  );
+
+  server.registerTool(
+    "agenthub_fetch_distribution_file",
+    {
+      title: "AgentHub: Fetch Distribution File",
+      description:
+        "Fetch a specific file from a generated distribution bundle.\n" +
+        "- version: string or 'latest' (default 'latest').\n" +
+        "- distribution: distribution slug (default 'claude').\n" +
+        "- file_path: relative path inside the distribution bundle, e.g. 'SKILL.md'.\n" +
+        "Returns raw file text.",
+      inputSchema: {
+        tool_id: z.string().describe("Tool folder under agents/"),
+        version: z.string().optional().default("latest"),
+        distribution: z.string().optional().default("claude"),
+        file_path: z.string().describe("Relative file path inside the distribution bundle")
+      }
+    },
+    async ({ tool_id, version = "latest", distribution = "claude", file_path }) => {
+      const selectedVersion = await resolveVersion({ fs, path, AGENTS_DIR, tool_id, version });
+      const fileText = await readDistributionFile({
+        fs,
+        path,
+        DISTRIBUTIONS_DIR,
+        tool_id,
+        version: selectedVersion,
+        distribution,
+        filePath: file_path
+      });
+
+      return { content: [{ type: "text", text: fileText }] };
+    }
+  );
+
   // Optional helper: return same docs available via GET /mcp as an MCP tool
   server.registerTool(
     "agenthub_docs",
@@ -271,6 +377,24 @@ async function listVersions({ fs, path, AGENTS_DIR, tool_id }) {
     .map((file) => file.replace(/\.md$/i, "")))];
 }
 
+async function resolveVersion({ fs, path, AGENTS_DIR, tool_id, version = "latest" }) {
+  const versions = await listVersions({ fs, path, AGENTS_DIR, tool_id }).catch(() => []);
+  if (!versions.length) {
+    throw new Error(`Unknown tool_id '${tool_id}'. No versions found under agents/${tool_id}.`);
+  }
+
+  let selected = version;
+  if (version === "latest") {
+    selected = [...versions].sort().reverse()[0];
+  }
+
+  if (!versions.includes(selected)) {
+    throw new Error(`Unknown version '${version}' for tool '${tool_id}'. Available: [${versions.join(", ")}]`);
+  }
+
+  return selected;
+}
+
 async function readAgentByName({ fs, path, AGENTS_DIR, name, version }) {
   let v = version;
   if (v === "latest") {
@@ -280,6 +404,119 @@ async function readAgentByName({ fs, path, AGENTS_DIR, name, version }) {
   }
   const filePath = path.join(AGENTS_DIR, name, `${v}.md`);
   return await fs.readFile(filePath, "utf-8");
+}
+
+async function listDistributions({ fs, path, DISTRIBUTIONS_DIR, tool_id, version, distributionLabels }) {
+  const distributions = [];
+  const manifestPath = path.join(DISTRIBUTIONS_DIR, tool_id, version, "manifest.json");
+  try {
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+    distributions.push({
+      distribution: manifest.distribution || "claude",
+      label: distributionLabels[manifest.distribution || "claude"] || manifest.distribution || "claude",
+      entrypoint: manifest.entrypoint,
+      files: manifest.files,
+      description: manifest.description
+    });
+  } catch (error) {
+    if (error && error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  return distributions;
+}
+
+function normalizeDistributionFilePath(filePath = "") {
+  const normalized = String(filePath || "").replace(/^\/+/, "");
+  if (!normalized || normalized.includes("..") || pathIsAbsolute(normalized)) {
+    throw new Error(`Invalid distribution file path '${filePath}'. Expected a relative file path inside the bundle.`);
+  }
+  return normalized;
+}
+
+function pathIsAbsolute(candidate) {
+  return candidate.startsWith("/") || /^[A-Za-z]:[\\/]/.test(candidate);
+}
+
+async function readDistributionManifest({ fs, path, DISTRIBUTIONS_DIR, tool_id, version, distribution }) {
+  if (distribution !== "claude") {
+    throw new Error(`Unknown distribution '${distribution}' for tool '${tool_id}'. Available: [claude]`);
+  }
+
+  const manifestPath = path.join(DISTRIBUTIONS_DIR, tool_id, version, "manifest.json");
+  let manifest;
+  try {
+    manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      throw new Error(
+        `No '${distribution}' distribution found for tool '${tool_id}' at version '${version}'.`
+      );
+    }
+    throw error;
+  }
+
+  return {
+    manifest,
+    bundleDir: path.join(DISTRIBUTIONS_DIR, tool_id, version)
+  };
+}
+
+async function readDistributionFile({ fs, path, DISTRIBUTIONS_DIR, tool_id, version, distribution, filePath }) {
+  const { manifest, bundleDir } = await readDistributionManifest({
+    fs,
+    path,
+    DISTRIBUTIONS_DIR,
+    tool_id,
+    version,
+    distribution
+  });
+  const normalized = normalizeDistributionFilePath(filePath);
+  if (!manifest.files.includes(normalized)) {
+    throw new Error(
+      `Unknown file '${filePath}' for distribution '${distribution}' on tool '${tool_id}' version '${version}'. ` +
+      `Available: [${manifest.files.join(", ")}]`
+    );
+  }
+  return await fs.readFile(path.join(bundleDir, normalized), "utf8");
+}
+
+async function readDistributionBundle({
+  fs,
+  path,
+  DISTRIBUTIONS_DIR,
+  tool_id,
+  version,
+  distribution,
+  distributionLabels
+}) {
+  const { manifest, bundleDir } = await readDistributionManifest({
+    fs,
+    path,
+    DISTRIBUTIONS_DIR,
+    tool_id,
+    version,
+    distribution
+  });
+
+  const files = [];
+  for (const file of manifest.files) {
+    files.push({
+      path: file,
+      content: await fs.readFile(path.join(bundleDir, file), "utf8")
+    });
+  }
+
+  return {
+    tool_id,
+    version,
+    distribution,
+    label: distributionLabels[distribution] || distribution,
+    entrypoint: manifest.entrypoint,
+    description: manifest.description,
+    files
+  };
 }
 
 function corsHeaders() {
@@ -350,6 +587,71 @@ function buildDocsJSON({ baseUrl }) {
         }
       },
       {
+        name: "agenthub_distributions",
+        description:
+          "List generated distributions for a tool_id and version, including Claude-compatible skill bundles when available.",
+        params: { tool_id: "string", version: "optional string|'latest' (default 'latest')" },
+        response: "JSON text: { tool_id, version, distributions: [{ distribution, label, entrypoint, files, description }] }",
+        examples: {
+          rpc: {
+            jsonrpc: "2.0",
+            id: "4",
+            method: "callTool",
+            params: { name: "agenthub_distributions", arguments: { tool_id: "react", version: "latest" } }
+          }
+        }
+      },
+      {
+        name: "agenthub_fetch_distribution",
+        description:
+          "Fetch a full generated distribution bundle for a tool_id and version. Today this is primarily used for Claude-compatible skill bundles.",
+        params: {
+          tool_id: "string",
+          version: "optional string|'latest' (default 'latest')",
+          distribution: "optional string (default 'claude')"
+        },
+        response: "JSON text with entrypoint and file contents",
+        examples: {
+          rpc: {
+            jsonrpc: "2.0",
+            id: "5",
+            method: "callTool",
+            params: {
+              name: "agenthub_fetch_distribution",
+              arguments: { tool_id: "react", version: "latest", distribution: "claude" }
+            }
+          }
+        }
+      },
+      {
+        name: "agenthub_fetch_distribution_file",
+        description:
+          "Fetch a single file from a generated distribution bundle, for example 'SKILL.md' or a references file.",
+        params: {
+          tool_id: "string",
+          version: "optional string|'latest' (default 'latest')",
+          distribution: "optional string (default 'claude')",
+          file_path: "relative file path inside the distribution bundle"
+        },
+        response: "Raw file text",
+        examples: {
+          rpc: {
+            jsonrpc: "2.0",
+            id: "6",
+            method: "callTool",
+            params: {
+              name: "agenthub_fetch_distribution_file",
+              arguments: {
+                tool_id: "react",
+                version: "latest",
+                distribution: "claude",
+                file_path: "SKILL.md"
+              }
+            }
+          }
+        }
+      },
+      {
         name: "agenthub_docs",
         description: "Return these docs as JSON text",
         params: {},
@@ -358,6 +660,7 @@ function buildDocsJSON({ baseUrl }) {
     ],
     notes: [
       "Agents directory layout: agents/<tool_id>/<version>.md",
+      "Claude-compatible distributions live under distributions/claude/<tool_id>/<version>/",
       "Filtering is only on tool_id; descriptions/tags are not indexed",
       "Versions are compared lexicographically (not semver-aware)",
       "No authentication; consider adding in production",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:claude-skill": "node scripts/pack-to-claude-skill.js",
     "generate:claude-skill:pilot": "node scripts/pack-to-claude-skill.js --pilot",
     "check:claude-skill": "node scripts/pack-to-claude-skill.js --pilot --check",
+    "check:mcp-distributions": "node scripts/check-mcp-distribution-tools.mjs",
     "build:site": "cd website && npm install && npm run build",
     "build": "npm run gen-mcp && npm run sync-agents && npm run build:site"
   },

--- a/scripts/check-mcp-distribution-tools.mjs
+++ b/scripts/check-mcp-distribution-tools.mjs
@@ -1,0 +1,98 @@
+import handler from "../netlify/functions/mcp.js";
+
+async function callTool(name, args = {}) {
+  const request = new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      "Accept": "application/json, text/event-stream",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: `${name}-1`,
+      method: "tools/call",
+      params: {
+        name,
+        arguments: args
+      }
+    })
+  });
+
+  const response = await handler(request);
+  const raw = await response.text();
+  const payload = parseMcpResponse(raw, response.headers.get("content-type") || "");
+  if (!response.ok || payload.error) {
+    throw new Error(`${name} failed: ${JSON.stringify(payload, null, 2)}`);
+  }
+
+  return payload.result?.content?.[0]?.text || "";
+}
+
+function parseMcpResponse(raw, contentType) {
+  if (/application\/json/i.test(contentType)) {
+    return JSON.parse(raw);
+  }
+
+  const dataLine = raw
+    .split("\n")
+    .find((line) => line.startsWith("data: "));
+  if (!dataLine) {
+    throw new Error(`Expected MCP stream response with a data line, got: ${raw}`);
+  }
+  return JSON.parse(dataLine.slice(6));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const distributionsText = await callTool("agenthub_distributions", {
+  tool_id: "react",
+  version: "latest"
+});
+const distributions = JSON.parse(distributionsText);
+assert(Array.isArray(distributions.distributions), "agenthub_distributions should return a distributions array");
+assert(
+  distributions.distributions.some((entry) => entry.distribution === "claude"),
+  "agenthub_distributions should report the claude distribution for react"
+);
+
+const bundleText = await callTool("agenthub_fetch_distribution", {
+  tool_id: "react",
+  version: "latest",
+  distribution: "claude"
+});
+const bundle = JSON.parse(bundleText);
+assert(bundle.distribution === "claude", "agenthub_fetch_distribution should return the claude distribution slug");
+assert(bundle.entrypoint === "SKILL.md", "agenthub_fetch_distribution should return SKILL.md as the entrypoint");
+assert(Array.isArray(bundle.files) && bundle.files.length > 0, "agenthub_fetch_distribution should include file contents");
+assert(bundle.files.some((file) => file.path === "SKILL.md"), "bundle should include SKILL.md");
+
+const skillText = await callTool("agenthub_fetch_distribution_file", {
+  tool_id: "react",
+  version: "latest",
+  distribution: "claude",
+  file_path: "SKILL.md"
+});
+assert(skillText.includes("# React"), "agenthub_fetch_distribution_file should return the requested file content");
+
+const packText = await callTool("agenthub_fetch", {
+  tool_id: "react",
+  version: "latest"
+});
+assert(packText.includes("# React"), "agenthub_fetch should continue to return canonical Markdown packs");
+
+const docsRequest = new Request("http://localhost/mcp?format=json", {
+  method: "GET",
+  headers: { "Accept": "application/json, text/event-stream" }
+});
+const docsResponse = await handler(docsRequest);
+const docs = JSON.parse(await docsResponse.text());
+assert(
+  Array.isArray(docs.tools) && docs.tools.some((tool) => tool.name === "agenthub_fetch_distribution"),
+  "GET /mcp?format=json should document the new distribution tools"
+);
+
+console.log("MCP distribution tool checks passed.");

--- a/tutorials/use-agent-hub-through-mcp.md
+++ b/tutorials/use-agent-hub-through-mcp.md
@@ -60,6 +60,9 @@ Today that surface includes:
 * `agenthub_list` — search or browse packs
 * `agenthub_versions` — list available versions for a tool
 * `agenthub_fetch` — fetch a specific version, or `latest`
+* `agenthub_distributions` — list generated distributions for a tool and version
+* `agenthub_fetch_distribution` — fetch a full generated bundle such as a Claude-compatible skill
+* `agenthub_fetch_distribution_file` — fetch one file from a generated bundle
 * `agenthub_docs` — fetch server and tooling docs
 
 This is the difference between manually opening a Markdown file for every session and letting your MCP-aware client pull the right pack when it actually needs it.
@@ -123,20 +126,23 @@ This is the easiest way to make Agent Hub available inside MCP-aware tools like 
 
 ## **Step 3: Inspect the Tool Surface**
 
-Once your client is connected, Agent Hub should appear as an MCP server with four tools.
+Once your client is connected, Agent Hub should appear as an MCP server with seven tools.
 
 At a high level:
 
 * use `agenthub_list` when you want to browse what exists
 * use `agenthub_versions` when you already know the tool ID
-* use `agenthub_fetch` when you want the actual pack text
+* use `agenthub_fetch` when you want the canonical Markdown pack text
+* use `agenthub_distributions` when you want to see which generated distributions exist
+* use `agenthub_fetch_distribution` when you want the full generated bundle
+* use `agenthub_fetch_distribution_file` when you want a single file such as `SKILL.md`
 * use `agenthub_docs` when you want the server’s own reference docs
 
 For example, a model can discover that `agent-hub` has multiple versions available, then fetch `latest` to verify the server and inspect the product pack itself.
 
 ---
 
-## **Step 4: Try a Real React Example**
+## **Step 4: Try a Real Agent Hub Pack Example**
 
 Here is a minimal JSON-RPC flow against the deployed endpoint.
 
@@ -210,7 +216,69 @@ That last response returns the raw Markdown pack your agent can use as runtime c
 
 ---
 
-## **Step 5: Know When to Use `latest` and When to Pin**
+## **Step 5: Fetch a Claude-Compatible Skill Bundle**
+
+If your client wants the generated Claude-compatible skill instead of the raw canonical pack, list the available distributions first:
+
+```bash
+curl -sS https://agent-hub-1.netlify.app/mcp \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "dist-1",
+    "method": "tools/call",
+    "params": {
+      "name": "agenthub_distributions",
+      "arguments": { "tool_id": "react", "version": "latest" }
+    }
+  }'
+```
+
+Fetch the full bundle:
+
+```bash
+curl -sS https://agent-hub-1.netlify.app/mcp \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "bundle-1",
+    "method": "tools/call",
+    "params": {
+      "name": "agenthub_fetch_distribution",
+      "arguments": { "tool_id": "react", "version": "latest", "distribution": "claude" }
+    }
+  }'
+```
+
+Or fetch only the entrypoint skill file:
+
+```bash
+curl -sS https://agent-hub-1.netlify.app/mcp \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "skill-1",
+    "method": "tools/call",
+    "params": {
+      "name": "agenthub_fetch_distribution_file",
+      "arguments": {
+        "tool_id": "react",
+        "version": "latest",
+        "distribution": "claude",
+        "file_path": "SKILL.md"
+      }
+    }
+  }'
+```
+
+Use this path when your client or install flow wants the generated Claude-compatible skill bundle rather than the raw Markdown pack.
+
+---
+
+## **Step 6: Know When to Use `latest` and When to Pin**
 
 Use `version: "latest"` when:
 
@@ -228,7 +296,7 @@ This is one of the quiet advantages of Agent Hub over ad hoc prompt snippets: ve
 
 ---
 
-## **Step 6: Use It the Way Agents Actually Work**
+## **Step 7: Use It the Way Agents Actually Work**
 
 The best workflow is not “fetch every pack all the time.”
 


### PR DESCRIPTION
## Summary

This PR adds distribution-aware MCP support for generated Claude-compatible skill bundles while preserving the existing Markdown-pack tools.

## What changed

- kept existing tools intact:
  - `agenthub_list`
  - `agenthub_versions`
  - `agenthub_fetch`
  - `agenthub_docs`
- added new distribution-aware tools:
  - `agenthub_distributions`
  - `agenthub_fetch_distribution`
  - `agenthub_fetch_distribution_file`
- updated MCP docs output to describe both canonical packs and generated Claude-compatible skills
- updated the MCP tutorial with examples for listing and fetching Claude-compatible skill bundles
- updated Netlify function packaging to include `distributions/**`
- added a local MCP validation script that exercises the new tools against the function directly

## Design choice

Per issue #13 PR 4 guidance, this PR uses **new distribution-specific tools** instead of overloading `agenthub_fetch` with new parameters. That keeps existing Markdown-pack clients working unchanged.

## Validation

- `npm run check:mcp-distributions`
- `npm run build`
- direct handler spot-check of `GET /mcp?format=json`

## Notes

- canonical Markdown pack retrieval remains unchanged
- this PR is stacked on #16 because the MCP surface now reads the generated pilot bundles under `distributions/claude/**`
- the Milestone B Claude Code login blocker from #15 still exists and is not resolved in this PR

Refs: #13
